### PR TITLE
Remove ability to lock to angles and add ability to lock to 'natural' orientation.

### DIFF
--- a/index.html
+++ b/index.html
@@ -470,7 +470,7 @@
               <i>orientations</i>.
               </li>
               <li>The <a>user agent</a> MUST change how the viewport is drawn
-              such as the <a>current screen orientation type</a> will be equal
+              so that the <a>current screen orientation type</a> will be equal
               to <i>orientation</i>.
               </li>
               <li>After the change has happened, the <a>user agent</a> MUST

--- a/index.html
+++ b/index.html
@@ -329,6 +329,9 @@
             any
           </dt>
           <dt>
+            natural
+          </dt>
+          <dt>
             landscape
           </dt>
           <dt>
@@ -407,6 +410,16 @@
                 <code>portrait-primary</code>, or
                 <code>portrait-secondary</code>, or both to
                 <var>orientations</var>.
+              </dd>
+              <dt>
+                <code>natural</code>
+              </dt>
+              <dd>
+                Append <code>portrait-primary</code>,
+                <code>portrait-secondary</code>, <code>landscape-primary</code>
+                or <code>landscape-secondary</code> to
+                <var>orientations</var> such as the associated screen
+                orientation angle is 0.
               </dd>
               <dt>
                 <code>any</code>

--- a/index.html
+++ b/index.html
@@ -346,18 +346,6 @@
           <dt>
             landscape-secondary
           </dt>
-          <dt>
-            0
-          </dt>
-          <dt>
-            90
-          </dt>
-          <dt>
-            180
-          </dt>
-          <dt>
-            270
-          </dt>
         </dl>
         <p>
           The steps to <dfn>apply an orientation lock</dfn> using
@@ -469,9 +457,8 @@
               <i>orientations</i>.
               </li>
               <li>The <a>user agent</a> MUST change how the viewport is drawn
-              such as the <a>current screen orientation type</a> or the
-              <a>current screen orientation angle</a> will be equal to
-              <i>orientation</i>.
+              such as the <a>current screen orientation type</a> will be equal
+              to <i>orientation</i>.
               </li>
               <li>After the change has happened, the <a>user agent</a> MUST
               prevent the <a>top-level browsing context</a> screen orientation
@@ -481,12 +468,10 @@
               </li>
             </ol>
           </li>
-          <li>If neither the <a>current screen orientation type</a> nor the <a>
-            current screen orientation angle</a> values are part of
-            <i>orientations</i>, the <a>user agent</a> MUST change how the
+          <li>If the <a>current screen orientation type</a> is not part of <i>
+            orientations</i>, the <a>user agent</a> MUST change how the
             viewport is drawn such as the <a>current screen orientation
-            type</a> or the <a>current screen orientation angle</a> will be
-            equal to one of <i>orientations</i>' values.
+            type</a> will be equal to one of <i>orientations</i>' values.
           </li>
           <li>Otherwise, depending on platform conventions, the <a>user
           agent</a> MAY change how the viewport is drawn in order to make it


### PR DESCRIPTION
Solves the following bug: https://www.w3.org/Bugs/Public/show_bug.cgi?id=25329

This push has two commits:
"Remove the ability to lock to angles." that removes the support for locking to 0, 90, 180 and 270.
"Add 'natural' orientation lock type." that adds support for locking to 'natural' which is equivalent to locking to angle 0.

Please ignore the following commit:
"Define what the term 'screen' means in the context of the specification."
