### PR TITLE
Add a link to web-platform-tests to the top of the spec

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,8 @@
             }
         ],
 
+        testSuiteURI: "https://github.com/w3c/web-platform-tests/tree/master/screen-orientation",
+
         otherLinks: [{
             key: 'Participate',
             data: [{


### PR DESCRIPTION
Many other specs that have something similar:
https://fetch.spec.whatwg.org/
https://w3c.github.io/IndexedDB/
https://notifications.spec.whatwg.org/
https://w3c.github.io/ServiceWorker/
https://webaudio.github.io/web-audio-api/
https://xhr.spec.whatwg.org/