### PR TITLE
Reference correct promise at the "apply an orientation lock" operation

### DIFF
--- a/index.html
+++ b/index.html
@@ -512,9 +512,9 @@
               </dd>
             </dl>
           </li>
-          <li>Set <var>pending-promise</var> to be a newly-create a promise.
+          <li>Set <var>doc</var>'s <a>pending promise</a> to a newly-created promise.
           </li>
-          <li>Return <var>pending-promise</var> and continue asynchronously.
+          <li>Return <var>doc</var>'s <a>pending promise</a> and continue asynchronously.
           </li>
           <li>
             <a>Lock the orientation</a> of the <a>document</a> to


### PR DESCRIPTION
Fixes #94. In the "apply an orientation lock" operation reference
the doc's pending promise instead of the 'pending-promise' variable.