### PR TITLE
Add [SameObject] to the `Screen.orientation` attribute

### DIFF
--- a/index.html
+++ b/index.html
@@ -208,7 +208,7 @@
         interface [[!CSSOM-VIEW]], which this specification extends:
         <pre class='idl'>
           partial interface Screen {
-            readonly attribute ScreenOrientation orientation;
+            [SameObject] readonly attribute ScreenOrientation orientation;
           };
         </pre>
         <p>


### PR DESCRIPTION
There should not be any new Orientation instances created on a Screen.orientation call.