### PR TITLE
Fix event firing

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,11 +112,6 @@
         </li>
         <li>
           <dfn><a href=
-          "https://html.spec.whatwg.org/multipage/webappapis.html#fire-a-simple-event">fire
-          a simple event</a></dfn>
-        </li>
-        <li>
-          <dfn><a href=
           "https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event
           handler</a></dfn>
         </li>
@@ -187,6 +182,11 @@
         <dfn><a href=
         'https://www.w3.org/TR/page-visibility/#now-visible-algorithm'>now
         visible algorithm</a></dfn> is defined in [[!PAGE-VISIBILITY]].
+      </p>
+      <p>
+        <dfn><a href=
+        'https://dom.spec.whatwg.org/#concept-event-fire'>fire
+        an event</a></dfn> is defined in [[!DOM]].
       </p>
       <p>
         <dfn><a href='https://github.com/whatwg/fullscreen/issues/16'
@@ -662,7 +662,7 @@
               change</code> when running the next step.
               </li>
               <li>
-                <a>Fire a simple event</a> named <code>change</code> at
+                <a>Fire an event</a> named <code>change</code> at
                 <var>doc</var> 's <a href=
                 "#widl-Screen-orientation"><code>screen.orientation</code></a>
                 object.
@@ -707,7 +707,7 @@
               </code> when running the next step.
               </li>
               <li>
-                <a>Fire a simple event</a> named <code>change</code> at the
+                <a>Fire an event</a> named <code>change</code> at the
                 <a>document</a>'s <a href=
                 "#widl-Screen-orientation"><code>screen.orientation</code></a>
                 object.


### PR DESCRIPTION
Fixes #93. Use "fire an event" operation instead of the removed "fire a simple event".