### PR TITLE
Fix ReSpec errors

### DIFF
--- a/index.html
+++ b/index.html
@@ -659,7 +659,7 @@
               </li>
               <li>
                 <a>Fire an event</a> named <code>change</code> at
-                <var>doc</var> 's <a><code>screen.orientation</code></a>object.
+                <var>doc</var> 's <a>screen.orientation</a>object.
               </li>
             </ol>
           </li>
@@ -701,8 +701,7 @@
               </li>
               <li>
                 <a>Fire an event</a> named <code>change</code> at the
-                <a>document</a>'s <a><code>screen.orientation</code></a>
-                object.
+                <a>document</a>'s <a>screen.orientation</a>object.
               </li>
             </ol>
           </li>
@@ -714,8 +713,8 @@
         </p>
         <div class="note">
           <p>
-            Developers need to be aware that a <a><code>screen.orientation
-            </code></a>object from a <a>document</a> that is not visible, as per
+            Developers need to be aware that a <a>screen.orientation</a>object 
+            from a <a>document</a> that is not visible, as per
             [[PAGE-VISIBILITY]], will not receive an orientation change event.
             This is to prevent unnecessary changes to layout, etc. in the
             non-visible web application.

--- a/index.html
+++ b/index.html
@@ -680,8 +680,8 @@
           </li>
           <li>If <var>type</var> is different from the <a>document</a>'s
           <a>current orientation type</a> or <var>angle</var> from the
-          <a>document</a>'s <a>current orientation angle</a>, run the
-          following sub-steps:
+          <a>document</a>'s <a>current orientation angle</a>, run the following
+          sub-steps:
             <ol>
               <li>If the <a>document</a>'s <a>pending promise</a> is not <code>
                 null</code>:
@@ -825,22 +825,31 @@
           Interaction with Web Content Accessibility Guidelines
         </h2>
         <p>
-            The Web Content Accessibility Guidelines 2.1 specification [[WCAG21]] includes a Success Criterion (<a href="https://www.w3.org/TR/WCAG21/#orientation">SC 1.3.4</a>) related to screen orientation.
+          The Web Content Accessibility Guidelines 2.1 specification [[WCAG21]]
+          includes a Success Criterion (<a href=
+          "https://www.w3.org/TR/WCAG21/#orientation">SC 1.3.4</a>) related to
+          screen orientation.
         </p>
-
         <p>
-          ​The intent of this Success Criterion is to ensure that all
-          <a href="https://www.w3.org/TR/WCAG21/#dfn-essential">essential</a> content and functionality is available regardless of the display orientation (portrait or landscape). Some
-          websites and applications automatically set the screen to a particular display orientation and expect that users will respond
-          by rotating their device to match.
+          ​The intent of this Success Criterion is to ensure that all <a href=
+          "https://www.w3.org/TR/WCAG21/#dfn-essential">essential</a> content
+          and functionality is available regardless of the display orientation
+          (portrait or landscape). Some websites and applications automatically
+          set the screen to a particular display orientation and expect that
+          users will respond by rotating their device to match.
         </p>
-
         <p>
-          However, some users may have their devices mounted in a fixed orientation (e.g. on the arm of a power wheelchair). Therefore,
-          websites and applications need to support both orientations by making sure
-          <a href="https://www.w3.org/TR/WCAG21/#dfn-essential">essential</a> content and functionality is available in each orientation. While the order of content and method of functionality
-          may have differences the content and functionality must always be available. When a particular orientation is
-          <a href="https://www.w3.org/TR/WCAG21/#dfn-essential">essential</a>, the user needs to be advised of the orientation requirements.​
+          However, some users may have their devices mounted in a fixed
+          orientation (e.g. on the arm of a power wheelchair). Therefore,
+          websites and applications need to support both orientations by making
+          sure <a href=
+          "https://www.w3.org/TR/WCAG21/#dfn-essential">essential</a> content
+          and functionality is available in each orientation. While the order
+          of content and method of functionality may have differences the
+          content and functionality must always be available. When a particular
+          orientation is <a href=
+          "https://www.w3.org/TR/WCAG21/#dfn-essential">essential</a>, the user
+          needs to be advised of the orientation requirements.​
         </p>
       </section>
     </section>
@@ -923,21 +932,19 @@
       <h2>
         Privacy and Security Considerations
       </h2>
-
-
       <section>
-        <h3>Access to aspects of a user’s local computing environment</h3>
+        <h3>
+          Access to aspects of a user’s local computing environment
+        </h3>
         <p>
           The screen orientation type and angle of the device can be accessed
           with the API specified in this document, and can be a potential
           fingerprinting vector.
-        </p>
-          The screen orientation type can already be known by using the
-          screen width and height. In practice, the additional information
-          provided with the API concerning the angle of the device and the
-          primary or secondary screen orientation is unlikely to be used by
-          any competent attack.
-        </p>
+        </p>The screen orientation type can already be known by using the
+        screen width and height. In practice, the additional information
+        provided with the API concerning the angle of the device and the
+        primary or secondary screen orientation is unlikely to be used by any
+        competent attack.
       </section>
     </section>
     <section class='appendix'>

--- a/index.html
+++ b/index.html
@@ -659,7 +659,7 @@
               </li>
               <li>
                 <a>Fire an event</a> named <code>change</code> at
-                <var>doc</var> 's <a>screen.orientation</a>object.
+                <var>doc</var>'s <a>screen.orientation</a> object.
               </li>
             </ol>
           </li>
@@ -701,7 +701,7 @@
               </li>
               <li>
                 <a>Fire an event</a> named <code>change</code> at the
-                <a>document</a>'s <a>screen.orientation</a>object.
+                <a>document</a>'s <a>screen.orientation</a> object.
               </li>
             </ol>
           </li>
@@ -713,7 +713,7 @@
         </p>
         <div class="note">
           <p>
-            Developers need to be aware that a <a>screen.orientation</a>object
+            Developers need to be aware that a <a>screen.orientation</a> object
             from a <a>document</a> that is not visible, as per
             [[PAGE-VISIBILITY]], will not receive an orientation change event.
             This is to prevent unnecessary changes to layout, etc. in the

--- a/index.html
+++ b/index.html
@@ -680,7 +680,7 @@
           </li>
           <li>If <var>type</var> is different from the <a>document</a>'s
           <a>current orientation type</a> or <var>angle</var> from the
-          <a>document</a> 's <a>current orientation angle</a>, run the
+          <a>document</a>'s <a>current orientation angle</a>, run the
           following sub-steps:
             <ol>
               <li>If the <a>document</a>'s <a>pending promise</a> is not <code>
@@ -713,7 +713,7 @@
         </p>
         <div class="note">
           <p>
-            Developers need to be aware that a <a>screen.orientation</a>object 
+            Developers need to be aware that a <a>screen.orientation</a>object
             from a <a>document</a> that is not visible, as per
             [[PAGE-VISIBILITY]], will not receive an orientation change event.
             This is to prevent unnecessary changes to layout, etc. in the

--- a/index.html
+++ b/index.html
@@ -205,7 +205,7 @@
         </p>
       </section>
       <section data-dfn-for='ScreenOrientation' data-link-for=
-      'ScreenOrientation'>
+      'ScreenOrientation'  id='widl-Screen-orientation'>
         <h2>
           <dfn>ScreenOrientation</dfn> interface
         </h2>

--- a/index.html
+++ b/index.html
@@ -720,7 +720,7 @@
             Developers need to be aware that a <a href=
             "#widl-Screen-orientation"><code>screen.orientation</code></a>
             object from a <a>document</a> that is not visible, as per
-            [[!PAGE-VISIBILITY]], will not receive an orientation change event.
+            [[PAGE-VISIBILITY]], will not receive an orientation change event.
             This is to prevent unnecessary changes to layout, etc. in the
             non-visible web application.
           </p>

--- a/index.html
+++ b/index.html
@@ -940,11 +940,14 @@
           The screen orientation type and angle of the device can be accessed
           with the API specified in this document, and can be a potential
           fingerprinting vector.
-        </p>The screen orientation type can already be known by using the
-        screen width and height. In practice, the additional information
-        provided with the API concerning the angle of the device and the
-        primary or secondary screen orientation is unlikely to be used by any
-        competent attack.
+        </p>
+        <p>
+          The screen orientation type can already be known by using the screen
+          width and height. In practice, the additional information provided
+          with the API concerning the angle of the device and the primary or
+          secondary screen orientation is unlikely to be used by any competent
+          attack.
+        </p>
       </section>
     </section>
     <section class='appendix'>

--- a/index.html
+++ b/index.html
@@ -205,7 +205,7 @@
         </p>
       </section>
       <section data-dfn-for='ScreenOrientation' data-link-for=
-      'ScreenOrientation'  id='widl-Screen-orientation'>
+      'ScreenOrientation'>
         <h2>
           <dfn>ScreenOrientation</dfn> interface
         </h2>
@@ -659,9 +659,7 @@
               </li>
               <li>
                 <a>Fire an event</a> named <code>change</code> at
-                <var>doc</var> 's <a href=
-                "#widl-Screen-orientation"><code>screen.orientation</code></a>
-                object.
+                <var>doc</var> 's <a><code>screen.orientation</code></a>object.
               </li>
             </ol>
           </li>
@@ -703,8 +701,7 @@
               </li>
               <li>
                 <a>Fire an event</a> named <code>change</code> at the
-                <a>document</a>'s <a href=
-                "#widl-Screen-orientation"><code>screen.orientation</code></a>
+                <a>document</a>'s <a><code>screen.orientation</code></a>
                 object.
               </li>
             </ol>
@@ -717,9 +714,8 @@
         </p>
         <div class="note">
           <p>
-            Developers need to be aware that a <a href=
-            "#widl-Screen-orientation"><code>screen.orientation</code></a>
-            object from a <a>document</a> that is not visible, as per
+            Developers need to be aware that a <a><code>screen.orientation
+            </code></a>object from a <a>document</a> that is not visible, as per
             [[PAGE-VISIBILITY]], will not receive an orientation change event.
             This is to prevent unnecessary changes to layout, etc. in the
             non-visible web application.


### PR DESCRIPTION
ReSpec is showing two warnings:
- Remove '!' from the start of the reference [[!PAGE-VISIBILITY]].
- Broken local reference found in document in three places (all from `#widl-Screen-Orientation.`)

For the second, I have manually added in a corresponding id as stated in the ReSpec docs, since ReSpec has automatically generated these`#widl` identifiers.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Johanna-hub/screen-orientation/pull/122.html" title="Last updated on Oct 17, 2018, 2:04 AM GMT (fedabe4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-orientation/122/86e613e...Johanna-hub:fedabe4.html" title="Last updated on Oct 17, 2018, 2:04 AM GMT (fedabe4)">Diff</a>