### PR TITLE
Editorial: Move and edit conformance section

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,18 +50,6 @@
         This document is a work in progress.
       </p>
     </section>
-    <section id='conformance'>
-      <p>
-        This specification defines conformance criteria that apply to a single
-        product: the <dfn>user agent</dfn> that implements the interfaces that
-        it contains.
-      </p>
-      <p>
-        Implementations that use ECMAScript to expose the APIs defined in this
-        specification MUST implement them in a manner consistent with the
-        ECMAScript Bindings defined in the Web IDL specification [[!WEBIDL]].
-      </p>
-    </section>
     <section>
       <h2>
         Dependencies
@@ -913,6 +901,13 @@
           attack.
         </p>
       </section>
+    </section>
+    <section id='conformance'>
+      <p>
+        This specification defines conformance criteria that apply to a single
+        product: the <dfn>user agent</dfn> that implements the interfaces that
+        it contains.
+      </p>
     </section>
     <section class='appendix'>
       <h2>


### PR DESCRIPTION
Moved conformance section to the end of the specification and cut the statement regarding ECMAScript.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Johanna-hub/screen-orientation/pull/128.html" title="Last updated on Jan 7, 2019, 12:50 PM UTC (299b81b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-orientation/128/03dce65...Johanna-hub:299b81b.html" title="Last updated on Jan 7, 2019, 12:50 PM UTC (299b81b)">Diff</a>