### PR TITLE
Editorial: Move and edit Dependencies section

### DIFF
--- a/index.html
+++ b/index.html
@@ -858,16 +858,16 @@
       </p>
       <p>
         The following is defined in [[FULLSCREEN]]: <dfn data-cite=
-        "FULLSCREEN/#fullscreen-element">fullscreen element</dfn>.
+        "FULLSCREEN#fullscreen-element">fullscreen element</dfn>.
       </p>
       <p>
         The following is defined in [[PAGE-VISIBILITY]]: <dfn data-cite=
-        "PAGE-VISIBILITY/#dfn-now-visible-algorithm">now visible
+        "PAGE-VISIBILITY#dfn-now-visible-algorithm">now visible
         algorithm</dfn>.
       </p>
       <p>
         The following is defined in [[DOM]]: <dfn data-cite=
-        "DOM/#concept-event-fire">fire an event</dfn>.
+        "DOM#concept-event-fire">fire an event</dfn>.
       </p>
       <p>
         The following is used but not defined in [[FULLSCREEN]]: <dfn><a href=

--- a/index.html
+++ b/index.html
@@ -832,41 +832,51 @@
         Dependencies
       </h2>
       <p>
-        The following concepts and interfaces are defined in [[HTML]]: <dfn data-cite="!HTML/webappapis.html#event-handlers">event
-            handler</dfn>, <dfn data-cite="!HTML/webappapis.html#event-handler-event-type">event
-              handler event type</dfn>, <dfn data-cite="!HTML/webappapis.html#concept-task">task</dfn>, <code><dfn data-cite=
-                "!HTML/window-object.html#window">Window</dfn></code>, <code><dfn data-cite="!HTML/dom.html#document">Document</dfn></code>, <dfn data-cite="!HTML/browsers.html#browsing-context">browsing
-                  context</dfn>, <dfn data-cite=
-                  "!HTML/browsers.html#top-level-browsing-context">top-level browsing
-                  context</dfn>, browsing context's <dfn data-cite=
-                  "!HTML/browsers.html#active-document">active document</dfn>, <dfn data-cite="!HTML/browsers.html#navigate">navigated</dfn>
-                  browsing context, <dfn data-cite=
-                  "!HTML/browsers.html#active-sandboxing-flag-set">active sandboxing
-                  flag set</dfn>, <dfn data-cite=
-                  "!HTML/browsers.html#sandboxed-orientation-lock-browsing-context-flag">
-                  sandboxed orientation lock browsing context flag</dfn>, <dfn data-cite=
-                  "!HTML/webappapis.html#responsible-document">responsible
-                  document</dfn>,  <dfn data-cite=
-                  "!HTML/browsers.html#list-of-the-descendant-browsing-contexts">list
-                  of the descendant browsing contexts</dfn>.
+        The following concepts and interfaces are defined in [[HTML]]:
+        <dfn data-cite="!HTML/webappapis.html#event-handlers">event
+        handler</dfn>, <dfn data-cite=
+        "!HTML/webappapis.html#event-handler-event-type">event handler event
+        type</dfn>, <dfn data-cite=
+        "!HTML/webappapis.html#concept-task">task</dfn>, <code><dfn data-cite=
+        "!HTML/window-object.html#window">Window</dfn></code>,
+        <code><dfn data-cite="!HTML/dom.html#document">Document</dfn></code>,
+        <dfn data-cite="!HTML/browsers.html#browsing-context">browsing
+        context</dfn>, <dfn data-cite=
+        "!HTML/browsers.html#top-level-browsing-context">top-level browsing
+        context</dfn>, browsing context's <dfn data-cite=
+        "!HTML/browsers.html#active-document">active document</dfn>,
+        <dfn data-cite="!HTML/browsers.html#navigate">navigated</dfn> browsing
+        context, <dfn data-cite=
+        "!HTML/browsers.html#active-sandboxing-flag-set">active sandboxing flag
+        set</dfn>, <dfn data-cite=
+        "!HTML/browsers.html#sandboxed-orientation-lock-browsing-context-flag">sandboxed
+        orientation lock browsing context flag</dfn>, <dfn data-cite=
+        "!HTML/webappapis.html#responsible-document">responsible
+        document</dfn>, <dfn data-cite=
+        "!HTML/browsers.html#list-of-the-descendant-browsing-contexts">list of
+        the descendant browsing contexts</dfn>.
       </p>
       <p>
-        The following is defined in [[FULLSCREEN]]: <dfn data-cite="!FULLSCREEN/#fullscreen-element">fullscreen
-        element</dfn>.
+        The following is defined in [[FULLSCREEN]]: <dfn data-cite=
+        "!FULLSCREEN/#fullscreen-element">fullscreen element</dfn>.
       </p>
       <p>
-        The following is defined in [[PAGE-VISIBILITY]]: <dfn data-cite="!PAGE-VISIBILITY/#dfn-now-visible-algorithm">now
-        visible algorithm</dfn>.
-      </p>
-      <p> 
-        The following is defined in [[DOM]]: <dfn data-cite="!DOM/#concept-event-fire">fire an event</dfn>.
+        The following is defined in [[PAGE-VISIBILITY]]: <dfn data-cite=
+        "!PAGE-VISIBILITY/#dfn-now-visible-algorithm">now visible
+        algorithm</dfn>.
       </p>
       <p>
-        The following is used but not defined in [[FULLSCREEN]]: <dfn><a href='https://github.com/whatwg/fullscreen/issues/16'>animation
-        frame task</a></dfn>.
+        The following is defined in [[DOM]]: <dfn data-cite=
+        "!DOM/#concept-event-fire">fire an event</dfn>.
+      </p>
+      <p>
+        The following is used but not defined in [[FULLSCREEN]]: <dfn><a href=
+        'https://github.com/whatwg/fullscreen/issues/16'>animation frame
+        task</a></dfn>.
       </p>
       <div class='issue'>
-        This should now be updated since the <a>animation frame task</a> issue is recently resolved and the timing is now defined.
+        This should now be updated since the <a>animation frame task</a> issue
+        is recently resolved and the timing is now defined.
       </div>
     </section>
     <section class='appendix'>

--- a/index.html
+++ b/index.html
@@ -64,93 +64,6 @@
     </section>
     <section>
       <h2>
-        Dependencies
-      </h2>
-      <p>
-        The following concepts and interfaces are defined in [[!HTML]]:
-      </p>
-      <ul>
-        <li>
-          <dfn data-cite="!HTML/webappapis.html#queue-a-task">queue a
-          task</dfn>
-        </li>
-        <li>
-          <dfn data-cite="!HTML/webappapis.html#event-handlers">event
-          handler</dfn>
-        </li>
-        <li>
-          <dfn data-cite="!HTML/webappapis.html#event-handler-event-type">event
-          handler event type</dfn>
-        </li>
-        <li>
-          <dfn data-cite="!HTML/webappapis.html#concept-task">task</dfn>
-        </li>
-        <li>
-          <code><dfn data-cite=
-          "!HTML/window-object.html#window">Window</dfn></code>
-        </li>
-        <li>
-          <code><dfn data-cite="!HTML/dom.html#document">Document</dfn></code>
-        </li>
-        <li>
-          <dfn data-cite="!HTML/browsers.html#browsing-context">browsing
-          context</dfn>
-        </li>
-        <li>
-          <dfn data-cite=
-          "!HTML/browsers.html#top-level-browsing-context">top-level browsing
-          context</dfn>
-        </li>
-        <li>browsing context's <dfn data-cite=
-        "!HTML/browsers.html#active-document">active document</dfn>
-        </li>
-        <li>
-          <dfn data-cite="!HTML/browsers.html#navigate">navigated</dfn>
-          browsing context
-        </li>
-        <li>
-          <dfn data-cite=
-          "!HTML/browsers.html#active-sandboxing-flag-set">active sandboxing
-          flag set</dfn>
-        </li>
-        <li>
-          <dfn data-cite=
-          "!HTML/browsers.html#sandboxed-orientation-lock-browsing-context-flag">
-          sandboxed orientation lock browsing context flag</dfn>
-        </li>
-        <li>
-          <dfn data-cite=
-          "!HTML/webappapis.html#responsible-document">responsible
-          document</dfn>
-        </li>
-        <li>
-          <dfn data-cite=
-          "!HTML/browsers.html#list-of-the-descendant-browsing-contexts">list
-          of the descendant browsing contexts</dfn>
-        </li>
-      </ul>
-      <p>
-        <dfn data-cite="!FULLSCREEN/#fullscreen-element">fullscreen
-        element</dfn> is defined in [[!FULLSCREEN]].
-      </p>
-      <p>
-        <dfn data-cite="!PAGE-VISIBILITY/#dfn-now-visible-algorithm">now
-        visible algorithm</dfn> is defined in [[!PAGE-VISIBILITY]].
-      </p>
-      <p>
-        <dfn data-cite="!DOM/#concept-event-fire">fire an event</dfn> is
-        defined in [[!DOM]].
-      </p>
-      <p>
-        <dfn><a href='https://github.com/whatwg/fullscreen/issues/16'>animation
-        frame task</a></dfn> is not defined but used in [[!FULLSCREEN]].
-      </p>
-      <div class='issue'>
-        This should be updated when <a>animation frame task</a> gets defined.
-      </div>
-    </section>
-    <section>
-      <h2>
         Interface definitions
       </h2>
       <section>
@@ -913,6 +826,48 @@
           attack.
         </p>
       </section>
+    </section>
+    <section>
+      <h2>
+        Dependencies
+      </h2>
+      <p>
+        The following concepts and interfaces are defined in [[HTML]]: <dfn data-cite="!HTML/webappapis.html#event-handlers">event
+            handler</dfn>, <dfn data-cite="!HTML/webappapis.html#event-handler-event-type">event
+              handler event type</dfn>, <dfn data-cite="!HTML/webappapis.html#concept-task">task</dfn>, <code><dfn data-cite=
+                "!HTML/window-object.html#window">Window</dfn></code>, <code><dfn data-cite="!HTML/dom.html#document">Document</dfn></code>, <dfn data-cite="!HTML/browsers.html#browsing-context">browsing
+                  context</dfn>, <dfn data-cite=
+                  "!HTML/browsers.html#top-level-browsing-context">top-level browsing
+                  context</dfn>, browsing context's <dfn data-cite=
+                  "!HTML/browsers.html#active-document">active document</dfn>, <dfn data-cite="!HTML/browsers.html#navigate">navigated</dfn>
+                  browsing context, <dfn data-cite=
+                  "!HTML/browsers.html#active-sandboxing-flag-set">active sandboxing
+                  flag set</dfn>, <dfn data-cite=
+                  "!HTML/browsers.html#sandboxed-orientation-lock-browsing-context-flag">
+                  sandboxed orientation lock browsing context flag</dfn>, <dfn data-cite=
+                  "!HTML/webappapis.html#responsible-document">responsible
+                  document</dfn>,  <dfn data-cite=
+                  "!HTML/browsers.html#list-of-the-descendant-browsing-contexts">list
+                  of the descendant browsing contexts</dfn>.
+      </p>
+      <p>
+        The following is defined in [[FULLSCREEN]]: <dfn data-cite="!FULLSCREEN/#fullscreen-element">fullscreen
+        element</dfn>.
+      </p>
+      <p>
+        The following is defined in [[PAGE-VISIBILITY]]: <dfn data-cite="!PAGE-VISIBILITY/#dfn-now-visible-algorithm">now
+        visible algorithm</dfn>.
+      </p>
+      <p> 
+        The following is defined in [[DOM]]: <dfn data-cite="!DOM/#concept-event-fire">fire an event</dfn>.
+      </p>
+      <p>
+        The following is used but not defined in [[FULLSCREEN]]: <dfn><a href='https://github.com/whatwg/fullscreen/issues/16'>animation
+        frame task</a></dfn>.
+      </p>
+      <div class='issue'>
+        This should now be updated since the <a>animation frame task</a> issue is recently resolved and the timing is now defined.
+      </div>
     </section>
     <section class='appendix'>
       <h2>

--- a/index.html
+++ b/index.html
@@ -833,41 +833,41 @@
       </h2>
       <p>
         The following concepts and interfaces are defined in [[HTML]]:
-        <dfn data-cite="!HTML/webappapis.html#event-handlers">event
+        <dfn data-cite="HTML/webappapis.html#event-handlers">event
         handler</dfn>, <dfn data-cite=
-        "!HTML/webappapis.html#event-handler-event-type">event handler event
+        "HTML/webappapis.html#event-handler-event-type">event handler event
         type</dfn>, <dfn data-cite=
-        "!HTML/webappapis.html#concept-task">task</dfn>, <code><dfn data-cite=
-        "!HTML/window-object.html#window">Window</dfn></code>,
-        <code><dfn data-cite="!HTML/dom.html#document">Document</dfn></code>,
-        <dfn data-cite="!HTML/browsers.html#browsing-context">browsing
+        "HTML/webappapis.html#concept-task">task</dfn>, <code><dfn data-cite=
+        "HTML/window-object.html#window">Window</dfn></code>,
+        <code><dfn data-cite="HTML/dom.html#document">Document</dfn></code>,
+        <dfn data-cite="HTML/browsers.html#browsing-context">browsing
         context</dfn>, <dfn data-cite=
-        "!HTML/browsers.html#top-level-browsing-context">top-level browsing
+        "HTML/browsers.html#top-level-browsing-context">top-level browsing
         context</dfn>, browsing context's <dfn data-cite=
-        "!HTML/browsers.html#active-document">active document</dfn>,
-        <dfn data-cite="!HTML/browsers.html#navigate">navigated</dfn> browsing
+        "HTML/browsers.html#active-document">active document</dfn>,
+        <dfn data-cite="HTML/browsers.html#navigate">navigated</dfn> browsing
         context, <dfn data-cite=
-        "!HTML/browsers.html#active-sandboxing-flag-set">active sandboxing flag
+        "HTML/browsers.html#active-sandboxing-flag-set">active sandboxing flag
         set</dfn>, <dfn data-cite=
-        "!HTML/browsers.html#sandboxed-orientation-lock-browsing-context-flag">sandboxed
+        "HTML/browsers.html#sandboxed-orientation-lock-browsing-context-flag">sandboxed
         orientation lock browsing context flag</dfn>, <dfn data-cite=
-        "!HTML/webappapis.html#responsible-document">responsible
+        "HTML/webappapis.html#responsible-document">responsible
         document</dfn>, <dfn data-cite=
-        "!HTML/browsers.html#list-of-the-descendant-browsing-contexts">list of
+        "HTML/browsers.html#list-of-the-descendant-browsing-contexts">list of
         the descendant browsing contexts</dfn>.
       </p>
       <p>
         The following is defined in [[FULLSCREEN]]: <dfn data-cite=
-        "!FULLSCREEN/#fullscreen-element">fullscreen element</dfn>.
+        "FULLSCREEN/#fullscreen-element">fullscreen element</dfn>.
       </p>
       <p>
         The following is defined in [[PAGE-VISIBILITY]]: <dfn data-cite=
-        "!PAGE-VISIBILITY/#dfn-now-visible-algorithm">now visible
+        "PAGE-VISIBILITY/#dfn-now-visible-algorithm">now visible
         algorithm</dfn>.
       </p>
       <p>
         The following is defined in [[DOM]]: <dfn data-cite=
-        "!DOM/#concept-event-fire">fire an event</dfn>.
+        "DOM/#concept-event-fire">fire an event</dfn>.
       </p>
       <p>
         The following is used but not defined in [[FULLSCREEN]]: <dfn><a href=

--- a/index.html
+++ b/index.html
@@ -74,7 +74,6 @@
     <section data-dfn-for='Screen'>
       <h2>
         Extensions to the <a>Screen</a> interface
-
       </h2>
       <p>
         The <a data-cite="CSSOM-View">CSSOM View Module</a> specification
@@ -980,8 +979,8 @@
         set</dfn>, <dfn data-cite=
         "HTML/browsers.html#sandboxed-orientation-lock-browsing-context-flag">sandboxed
         orientation lock browsing context flag</dfn>, <dfn data-cite=
-        "HTML/webappapis.html#responsible-document">responsible
-        document</dfn>, <dfn data-cite=
+        "HTML/webappapis.html#responsible-document">responsible document</dfn>,
+        <dfn data-cite=
         "HTML/browsers.html#list-of-the-descendant-browsing-contexts">list of
         the descendant browsing contexts</dfn>.
       </p>


### PR DESCRIPTION
- Moved Dependencies to end of document
- Removed `queue a task` since this is not used in the spec
- HTML concepts are in one para rather than a list
- Removed [[! citations
- Made the other references consistent with the HTML example

I have kept in animation frame task as it is, but updated the issue to reflect that this needs to be looked at and changed since being resolved in https://github.com/whatwg/fullscreen/issues/16 . I will open an issue regarding clarification on this.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Johanna-hub/screen-orientation/pull/129.html" title="Last updated on Jan 9, 2019, 11:00 AM UTC (2ea9e48)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-orientation/129/211393f...Johanna-hub:2ea9e48.html" title="Last updated on Jan 9, 2019, 11:00 AM UTC (2ea9e48)">Diff</a>