### PR TITLE
Editorial: Edits to Interface Definitions

### DIFF
--- a/index.html
+++ b/index.html
@@ -154,10 +154,9 @@
         Extensions to the <a>Screen</a> interface
       </h2>
       <p>
-        The <a data-cite="CSSOM-View">CSSOM View Module</a> specification
-        defines the <code><dfn data-cite=
-        "CSSOM-View#screen">Screen</dfn></code> interface, which this
-        specification extends:
+      The <a data-cite="CSSOM-View">CSSOM View Module</a> specification
+      defines the <code><dfn data-cite="CSSOM-View#screen">Screen</dfn></code> interface, which this specification
+      extends:
       </p>
       <pre class='idl'>
           partial interface Screen {
@@ -169,8 +168,8 @@
           <dfn>orientation</dfn> attribute
         </h2>
         <p>
-          The <a data-link-for="Screen">orientation</a> attribute is an
-          instance of <a>ScreenOrientation</a>.
+          The <a data-link-for="Screen">orientation</a> attribute is an instance of
+          <a>ScreenOrientation</a>.
         </p>
       </section>
     </section>
@@ -300,8 +299,8 @@
         Concepts
       </h2>
       <p>
-        The term <a>screen</a> is equivalent to the screen of the output device
-        associated to the <a>Window</a>, as per [[!CSSOM-VIEW]].
+        The term <a>screen</a> is equivalent to the screen of the output
+        device associated to the <a>Window</a>, as per [[CSSOM-VIEW]].
       </p>
       <p>
         Algorithms defined in this specification assume that for each

--- a/index.html
+++ b/index.html
@@ -154,9 +154,10 @@
         Extensions to the <a>Screen</a> interface
       </h2>
       <p>
-      The <a data-cite="CSSOM-View">CSSOM View Module</a> specification
-      defines the <code><dfn data-cite="CSSOM-View#screen">Screen</dfn></code> interface, which this specification
-      extends:
+        The <a data-cite="CSSOM-View">CSSOM View Module</a> specification
+        defines the <code><dfn data-cite=
+        "CSSOM-View#screen">Screen</dfn></code> interface, which this
+        specification extends:
       </p>
       <pre class='idl'>
           partial interface Screen {
@@ -168,8 +169,8 @@
           <dfn>orientation</dfn> attribute
         </h2>
         <p>
-          The <a data-link-for="Screen">orientation</a> attribute is an instance of
-          <a>ScreenOrientation</a>.
+          The <a data-link-for="Screen">orientation</a> attribute is an
+          instance of <a>ScreenOrientation</a>.
         </p>
       </section>
     </section>
@@ -299,8 +300,8 @@
         Concepts
       </h2>
       <p>
-        The term <a>screen</a> is equivalent to the screen of the output
-        device associated to the <a>Window</a>, as per [[CSSOM-VIEW]].
+        The term <a>screen</a> is equivalent to the screen of the output device
+        associated to the <a>Window</a>, as per [[CSSOM-VIEW]].
       </p>
       <p>
         Algorithms defined in this specification assume that for each

--- a/index.html
+++ b/index.html
@@ -154,9 +154,10 @@
         Extensions to the <a>Screen</a> interface
       </h2>
       <p>
-      The <a data-cite="CSSOM-View">CSSOM View Module</a> specification
-      defines the <code><dfn data-cite="CSSOM-View#screen">Screen</dfn></code> interface, which this specification
-      extends:
+        The <a data-cite="CSSOM-View">CSSOM View Module</a> specification
+        defines the <code><dfn data-cite=
+        "CSSOM-View#screen">Screen</dfn></code> interface, which this
+        specification extends:
       </p>
       <pre class='idl'>
           partial interface Screen {
@@ -168,8 +169,8 @@
           <dfn>orientation</dfn> attribute
         </h2>
         <p>
-          The <a  data-link-for="Screen">orientation</a> attribute is an instance of
-          <a>ScreenOrientation</a>.
+          The <a data-link-for="Screen">orientation</a> attribute is an
+          instance of <a>ScreenOrientation</a>.
         </p>
       </section>
     </section>
@@ -299,8 +300,8 @@
         Concepts
       </h2>
       <p>
-        The term <a>screen</a> is equivalent to the screen of the output
-        device associated to the <a>Window</a>, as per [[!CSSOM-VIEW]].
+        The term <a>screen</a> is equivalent to the screen of the output device
+        associated to the <a>Window</a>, as per [[!CSSOM-VIEW]].
       </p>
       <p>
         Algorithms defined in this specification assume that for each

--- a/index.html
+++ b/index.html
@@ -300,7 +300,8 @@
         Concepts
       </h2>
       <p>
-        The term <dfn data-lt="screen concept" data-lt-noDefault>screen</dfn> is equivalent to the screen of the output device
+        The term <dfn data-lt="screen concept" data-lt-nodefault=
+        "">screen</dfn> is equivalent to the screen of the output device
         associated to the <a>Window</a>, as per [[CSSOM-VIEW]].
       </p>
       <p>

--- a/index.html
+++ b/index.html
@@ -300,7 +300,7 @@
         Concepts
       </h2>
       <p>
-        The term <a>screen</a> is equivalent to the screen of the output device
+        The term <dfn data-lt="screen concept" data-lt-noDefault>screen</dfn> is equivalent to the screen of the output device
         associated to the <a>Window</a>, as per [[CSSOM-VIEW]].
       </p>
       <p>

--- a/index.html
+++ b/index.html
@@ -149,12 +149,15 @@
         This should be updated when <a>animation frame task</a> gets defined.
       </div>
     </section>
-    <section>
+    <section data-dfn-for='Screen'>
       <h2>
         Extensions to the <a>Screen</a> interface
-      </h2>The <a data-cite="CSSOM-View">CSSOM View Module</a> specification
-      defines a <code>Screen</code> interface, which this specification
+      </h2>
+      <p>
+      The <a data-cite="CSSOM-View">CSSOM View Module</a> specification
+      defines the <code><dfn data-cite="CSSOM-View#screen">Screen</dfn></code> interface, which this specification
       extends:
+      </p>
       <pre class='idl'>
           partial interface Screen {
             [SameObject] readonly attribute ScreenOrientation orientation;
@@ -162,11 +165,11 @@
         </pre>
       <section>
         <h2>
-          <dfn data-dfn-for='Screen'>orientation</dfn> attribute
+          <dfn>orientation</dfn> attribute
         </h2>
         <p>
-          The <a>orientation</a> attribute is an instance of
-          <a>ScreenOrientation</a>, which is described below.
+          The <a  data-link-for="Screen">orientation</a> attribute is an instance of
+          <a>ScreenOrientation</a>.
         </p>
       </section>
     </section>
@@ -296,7 +299,7 @@
         Concepts
       </h2>
       <p>
-        The term <dfn>screen</dfn> is equivalent to the screen of the output
+        The term <a>screen</a> is equivalent to the screen of the output
         device associated to the <a>Window</a>, as per [[!CSSOM-VIEW]].
       </p>
       <p>

--- a/index.html
+++ b/index.html
@@ -149,25 +149,26 @@
         This should be updated when <a>animation frame task</a> gets defined.
       </div>
     </section>
-    <section>
-      <h2>
-        Interface definitions
-      </h2>
       <section>
         <h2>
           Extensions to the <a>Screen</a> interface
-        </h2>The CSSOM View specification defines a <code>Screen</code>
-        interface [[!CSSOM-VIEW]], which this specification extends:
+        </h2>The <a data-cite="CSSOM-View">CSSOM View Module</a> specification defines a <code>Screen</code>
+        interface, which this specification extends:
         <pre class='idl'>
           partial interface Screen {
             [SameObject] readonly attribute ScreenOrientation orientation;
           };
         </pre>
+        <section>
+        <h2>
+            <dfn data-dfn-for='Screen'>orientation</dfn> attribute
+          </h2>
         <p>
-          The <dfn data-dfn-for='Screen'>orientation</dfn> object is an
+          The <a>orientation</a> attribute is an
           instance of <a>ScreenOrientation</a>, which is described below.
         </p>
       </section>
+    </section>
       <section data-dfn-for='ScreenOrientation' data-link-for=
       'ScreenOrientation'>
         <h2>
@@ -183,13 +184,22 @@
             attribute EventHandler onchange;
           };
         </pre>
+        <section>
+        <h2>
+          <dfn>lock()</dfn> method
+        </h2>
         <p>
-          When the <dfn>lock()</dfn> method is invoked, the <a>user agent</a>
+          When the <a>lock()</a> method is invoked, the <a>user agent</a>
           MUST run the <a>apply an orientation lock</a> steps to the
           <a>responsible document</a> using <var>orientation</var>.
         </p>
+      </section>
+      <section>
+        <h2>
+          <dfn>unlock()</dfn> method
+        </h2>
         <p>
-          When the <dfn>unlock()</dfn> method is invoked, the <a>user agent</a>
+          When the <a>unlock()</a> method is invoked, the <a>user agent</a>
           MUST run the steps to <a>lock the orientation</a> of the
           <a>responsible document</a> to the <a>responsible document</a>'s
           <a>default orientation</a>.
@@ -201,13 +211,23 @@
           predict what the new orientation is going to be and even if it is
           going to change at all.
         </p>
+      </section>
+      <section>
+        <h2>
+          <dfn>type</dfn> attribute
+        </h2>
         <p>
-          When getting the <dfn>type</dfn> attribute, the <a>user agent</a>
+          When getting the <a>type</a> attribute, the <a>user agent</a>
           MUST return the <a>responsible document</a>'s <a>current orientation
           type</a>.
         </p>
+      </section>
+      <section>
+        <h2>
+          <dfn>angle</dfn> attribute
+        </h2>
         <p>
-          When getting the <dfn>angle</dfn> attribute, the <a>user agent</a>
+          When getting the <a>angle</a> attribute, the <a>user agent</a>
           MUST return the <a>responsible document</a>'s <a>current orientation
           angle</a>.
         </p>
@@ -227,9 +247,15 @@
             The value returned by this property is always in the range 0-359.
             It never returns negative values.
           </p>
+        </section>
         </div>
+        <section>
+          <h2>
+            <dfn>onchange</dfn> attribute
+          </h2>
+        </section>
         <p>
-          The <dfn>onchange</dfn> attribute is an <a>event handler</a> whose
+          The <a>onchange</a> attribute is an <a>event handler</a> whose
           corresponding <a>event handler event type</a> is
           <code>"change"</code>.
         </p>
@@ -265,7 +291,6 @@
           };
         </pre>
       </section>
-    </section>
     <section>
       <h2>
         Concepts

--- a/index.html
+++ b/index.html
@@ -149,32 +149,33 @@
         This should be updated when <a>animation frame task</a> gets defined.
       </div>
     </section>
-      <section>
-        <h2>
-          Extensions to the <a>Screen</a> interface
-        </h2>The <a data-cite="CSSOM-View">CSSOM View Module</a> specification defines a <code>Screen</code>
-        interface, which this specification extends:
-        <pre class='idl'>
+    <section>
+      <h2>
+        Extensions to the <a>Screen</a> interface
+      </h2>The <a data-cite="CSSOM-View">CSSOM View Module</a> specification
+      defines a <code>Screen</code> interface, which this specification
+      extends:
+      <pre class='idl'>
           partial interface Screen {
             [SameObject] readonly attribute ScreenOrientation orientation;
           };
         </pre>
-        <section>
+      <section>
         <h2>
-            <dfn data-dfn-for='Screen'>orientation</dfn> attribute
-          </h2>
+          <dfn data-dfn-for='Screen'>orientation</dfn> attribute
+        </h2>
         <p>
-          The <a>orientation</a> attribute is an
-          instance of <a>ScreenOrientation</a>, which is described below.
+          The <a>orientation</a> attribute is an instance of
+          <a>ScreenOrientation</a>, which is described below.
         </p>
       </section>
     </section>
-      <section data-dfn-for='ScreenOrientation' data-link-for=
-      'ScreenOrientation'>
-        <h2>
-          <dfn>ScreenOrientation</dfn> interface
-        </h2>
-        <pre class='idl'>
+    <section data-dfn-for='ScreenOrientation' data-link-for=
+    'ScreenOrientation'>
+      <h2>
+        <dfn>ScreenOrientation</dfn> interface
+      </h2>
+      <pre class='idl'>
           [Exposed=Window]
           interface ScreenOrientation : EventTarget {
             Promise&lt;void&gt; lock(OrientationLockType orientation);
@@ -184,14 +185,14 @@
             attribute EventHandler onchange;
           };
         </pre>
-        <section>
+      <section>
         <h2>
           <dfn>lock()</dfn> method
         </h2>
         <p>
-          When the <a>lock()</a> method is invoked, the <a>user agent</a>
-          MUST run the <a>apply an orientation lock</a> steps to the
-          <a>responsible document</a> using <var>orientation</var>.
+          When the <a>lock()</a> method is invoked, the <a>user agent</a> MUST
+          run the <a>apply an orientation lock</a> steps to the <a>responsible
+          document</a> using <var>orientation</var>.
         </p>
       </section>
       <section>
@@ -217,8 +218,8 @@
           <dfn>type</dfn> attribute
         </h2>
         <p>
-          When getting the <a>type</a> attribute, the <a>user agent</a>
-          MUST return the <a>responsible document</a>'s <a>current orientation
+          When getting the <a>type</a> attribute, the <a>user agent</a> MUST
+          return the <a>responsible document</a>'s <a>current orientation
           type</a>.
         </p>
       </section>
@@ -227,8 +228,8 @@
           <dfn>angle</dfn> attribute
         </h2>
         <p>
-          When getting the <a>angle</a> attribute, the <a>user agent</a>
-          MUST return the <a>responsible document</a>'s <a>current orientation
+          When getting the <a>angle</a> attribute, the <a>user agent</a> MUST
+          return the <a>responsible document</a>'s <a>current orientation
           angle</a>.
         </p>
         <div class='note'>
@@ -247,24 +248,23 @@
             The value returned by this property is always in the range 0-359.
             It never returns negative values.
           </p>
-        </section>
         </div>
-        <section>
-          <h2>
-            <dfn>onchange</dfn> attribute
-          </h2>
-        </section>
-        <p>
-          The <a>onchange</a> attribute is an <a>event handler</a> whose
-          corresponding <a>event handler event type</a> is
-          <code>"change"</code>.
-        </p>
       </section>
       <section>
         <h2>
-          <dfn>OrientationType</dfn> enum
+          <dfn>onchange</dfn> attribute
         </h2>
-        <pre class='idl'>
+      </section>
+      <p>
+        The <a>onchange</a> attribute is an <a>event handler</a> whose
+        corresponding <a>event handler event type</a> is <code>"change"</code>.
+      </p>
+    </section>
+    <section>
+      <h2>
+        <dfn>OrientationType</dfn> enum
+      </h2>
+      <pre class='idl'>
           enum OrientationType {
             "portrait-primary",
             "portrait-secondary",
@@ -272,13 +272,13 @@
             "landscape-secondary"
           };
         </pre>
-      </section>
-      <section data-link-for="OrientationLockType" data-dfn-for=
-      "OrientationLockType">
-        <h2>
-          <dfn>OrientationLockType</dfn> enum
-        </h2>
-        <pre class='idl'>
+    </section>
+    <section data-link-for="OrientationLockType" data-dfn-for=
+    "OrientationLockType">
+      <h2>
+        <dfn>OrientationLockType</dfn> enum
+      </h2>
+      <pre class='idl'>
           enum OrientationLockType {
             "any",
             "natural",
@@ -290,7 +290,7 @@
             "landscape-secondary"
           };
         </pre>
-      </section>
+    </section>
     <section>
       <h2>
         Concepts


### PR DESCRIPTION
- Removed the 

> 3. Interface Definitions

 heading as unnecessary
- Changed `CSSOM View` citation to `CSSOM View Module`
- Changed `orientation` object to attribute with own subheading
- Added `unlock`, `lock` method subheadings and `type`, `angle` and `onchange` attribute subheadings

(In 3.1 I can't get `orientation` in the text to link to the heading and getting ReSpec warning, advice welcome!)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Johanna-hub/screen-orientation/pull/130.html" title="Last updated on Jan 9, 2019, 10:06 AM UTC (4765034)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-orientation/130/03dce65...Johanna-hub:4765034.html" title="Last updated on Jan 9, 2019, 10:06 AM UTC (4765034)">Diff</a>