### PR TITLE
Editorial: Example 1

### DIFF
--- a/index.html
+++ b/index.html
@@ -541,9 +541,9 @@
       <pre class='example html'>
 &lt;script&gt;
 async function fullScreenCheck() {
-  if(document.fullscreenElement === null) {
-      await document.documentElement.requestFullscreen();
-  } 
+  if (document.fullscreenElement === null) {
+    await document.body.requestFullscreen();
+  }
 }
 
 async function unlock() {
@@ -563,7 +563,7 @@ async function rotate() {
 
 function show() {
   const { type, angle } = screen.orientation;
-  console.log(`Orientation type is ${type} + angle is ${angle}`);
+  console.log(`Orientation type is ${type} & angle is ${angle}`);
 }
 
 screen.orientation.addEventListener("change", show);

--- a/index.html
+++ b/index.html
@@ -570,7 +570,7 @@ screen.orientation.addEventListener("change", show);
 window.addEventListener("load", show);
 &lt;/script&gt;
 
-&lt;button onclick="rotate()"&gt;
+&lt;button onclick="rotate() id="rotate"&gt;
   Rotate
 &lt;/button&gt;
 &lt;button onclick='unlock()'&gt;

--- a/index.html
+++ b/index.html
@@ -529,10 +529,10 @@
         Examples
       </h2>
       <p>
-        In this example for a mobile device, clicking the Rotate button
-        makes a request to go fullscreen and then lock to the opposite
-        orientation. If the device is not in it's default orientation, pressing the unlock button
-        reverts the screen orientation back to default.
+        In this example for a mobile device, clicking the Rotate button makes a
+        request to go fullscreen and then lock to the opposite orientation. If
+        the device is not in it's default orientation, pressing the unlock
+        button reverts the screen orientation back to default.
       </p>
       <p>
         The log shows the change in orientation type and angle.

--- a/index.html
+++ b/index.html
@@ -529,11 +529,15 @@
         Examples
       </h2>
       <p>
-        In this example for a mobile phone,  clicking the landscape button makes a request to go fullscreen and then lock to landscape orientation.  
-        Once it is in landscape, the unlock button will take the screen orientation back to default (portrait) or the portrait button will also change it back to portrait.
+        In this example for a mobile phone, clicking the landscape button makes
+        a request to go fullscreen and then lock to landscape orientation. Once
+        it is in landscape, the unlock button will take the screen orientation
+        back to default (portrait) or the portrait button will also change it
+        back to portrait.
       </p>
       <p>
-        The log shows the change in orientation type and angle, and whether the event type is load or change.
+        The log shows the change in orientation type and angle, and whether the
+        event type is load or change.
       </p>
       <pre class='example html'>
 &lt;script&gt;

--- a/index.html
+++ b/index.html
@@ -531,8 +531,8 @@
       <p>
         In this example for a mobile device, clicking the Rotate button makes a
         request to go fullscreen and then lock to the opposite orientation. If
-        the device is not in it's default orientation, pressing the unlock
-        button reverts the screen orientation back to default.
+        the screen is not in default orientation, pressing the unlock button
+        reverts the screen orientation back.
       </p>
       <p>
         The log shows the change in orientation type and angle.

--- a/index.html
+++ b/index.html
@@ -529,28 +529,46 @@
         Examples
       </h2>
       <p>
-        This example shows the current screen orientation to the console every
-        time the screen orientation state changes.
+        In this example for a mobile phone,  clicking the landscape button makes a request to go fullscreen and then lock to landscape orientation.  
+        Once it is in landscape, the unlock button will take the screen orientation back to default (portrait) or the portrait button will also change it back to portrait.
+      </p>
+      <p>
+        The log shows the change in orientation type and angle, and whether the event type is load or change.
       </p>
       <pre class='example html'>
 &lt;script&gt;
-  var show = function() {
-     console.log("Orientation type is " + screen.orientation.type);
-     console.log("Orientation angle is " + screen.orientation.angle);
-  }
+async function lockLandscape(){
+  await document.documentElement.requestFullscreen() 
+  await screen.orientation.lock('landscape');
+}
 
-  screen.orientation.addEventListener("change", show);
-  window.onload = show;
+async function unlock() {
+  await screen.orientation.unlock();
+}
+
+async function portrait(){
+  await screen.orientation.lock('portrait');
+}
+
+const { type, angle } = screen.orientation
+function show(event) {
+ console.log("Orientation type is " + screen.orientation.type);
+ console.log("Orientation angle is " + screen.orientation.angle);
+ console.log("Event Type is " + event.type)
+}
+
+screen.orientation.addEventListener("change", show);
+window.onload = show;
 &lt;/script&gt;
 
-&lt;button onclick='screen.orientation.unlock()'&gt;
+&lt;button onclick="lockLandscape()"&gt;
+  Lock to landscape
+&lt;/button&gt;
+&lt;button onclick='unlock()'&gt;
   Unlock
 &lt;/button&gt;
-&lt;button onclick="screen.orientation.lock('portrait')"&gt;
-  Lock to portrait
-&lt;/button&gt;
-&lt;button onclick="screen.orientation.lock('landscape')"&gt;
-  Lock to landscape
+&lt;button onclick="portrait()"&gt;
+  Portrait
 &lt;/button&gt;
 </pre>
       <p>

--- a/index.html
+++ b/index.html
@@ -529,14 +529,15 @@
         Examples
       </h2>
       <p>
-        In this example for a mobile device, clicking the landscape button makes
-        a request to go fullscreen and then lock to landscape orientation. Once
-        it is in landscape, pressing the unlock button reverts the screen orientation
-        back to default (portrait). Pressing the button labelled "portrait" will also change it
-        back to <a>portrait</a>.
+        In this example for a mobile device, clicking the landscape button
+        makes a request to go fullscreen and then lock to landscape
+        orientation. Once it is in landscape, pressing the unlock button
+        reverts the screen orientation back to default (portrait). Pressing the
+        button labelled "portrait" will also change it back to <a>portrait</a>.
       </p>
       <p>
-        The log shows the change in orientation type and angle, and the type of event.
+        The log shows the change in orientation type and angle, and the type of
+        event.
       </p>
       <pre class='example html'>
 &lt;script&gt;

--- a/index.html
+++ b/index.html
@@ -529,11 +529,10 @@
         Examples
       </h2>
       <p>
-        In this example for a mobile device, clicking the landscape button
-        makes a request to go fullscreen and then lock to landscape
-        orientation. Once it is in landscape, pressing the unlock button
-        reverts the screen orientation back to default (portrait). Pressing the
-        button labelled "portrait" will also change it back to <a>portrait</a>.
+        In this example for a mobile device, clicking the Rotate button
+        makes a request to go fullscreen and then lock to the opposite
+        orientation. If the device is not in it's default orientation, pressing the unlock button
+        reverts the screen orientation back to default.
       </p>
       <p>
         The log shows the change in orientation type and angle.
@@ -552,13 +551,13 @@ async function unlock() {
 }
 
 async function rotate() {
-  const rotate = document.getElementById("rotate");
+  const rotateBtn = document.getElementById("rotateBtn");
   await fullScreenCheck();
   const newOrientation = screen.orientation.type.startsWith("portrait")
     ? "landscape"
     : "portrait";
   await screen.orientation.lock(newOrientation);
-  rotate.textContent = `Rotate to ${newOrientation}`;
+  rotateBtn.textContent = `Rotate to ${newOrientation}`;
 }
 
 function show() {
@@ -570,7 +569,7 @@ screen.orientation.addEventListener("change", show);
 window.addEventListener("load", show);
 &lt;/script&gt;
 
-&lt;button onclick="rotate() id="rotate"&gt;
+&lt;button onclick="rotate() id="rotateBtn"&gt;
   Rotate
 &lt;/button&gt;
 &lt;button onclick='unlock()'&gt;

--- a/index.html
+++ b/index.html
@@ -529,28 +529,35 @@
         Examples
       </h2>
       <p>
-        In this example for a mobile phone, clicking the landscape button makes
+        In this example for a mobile device, clicking the landscape button makes
         a request to go fullscreen and then lock to landscape orientation. Once
-        it is in landscape, the unlock button will take the screen orientation
-        back to default (portrait) or the portrait button will also change it
-        back to portrait.
+        it is in landscape, pressing the unlock button reverts the screen orientation
+        back to default (portrait). Pressing the button labelled "portrait" will also change it
+        back to <a>portrait</a>.
       </p>
       <p>
-        The log shows the change in orientation type and angle, and whether the
-        event type is load or change.
+        The log shows the change in orientation type and angle, and the type of event.
       </p>
       <pre class='example html'>
 &lt;script&gt;
+async function fullScreenCheck() {
+  if(document.fullscreenElement === null) {
+      await document.documentElement.requestFullscreen();
+  } 
+}
+
 async function lockLandscape(){
-  await document.documentElement.requestFullscreen() 
+  fullScreenCheck() 
   await screen.orientation.lock('landscape');
 }
 
 async function unlock() {
+  fullScreenCheck();
   await screen.orientation.unlock();
 }
 
 async function portrait(){
+  fullScreenCheck();
   await screen.orientation.lock('portrait');
 }
 
@@ -562,7 +569,7 @@ function show(event) {
 }
 
 screen.orientation.addEventListener("change", show);
-window.onload = show;
+window.addEventListener("load", show);
 &lt;/script&gt;
 
 &lt;button onclick="lockLandscape()"&gt;

--- a/index.html
+++ b/index.html
@@ -548,17 +548,17 @@ async function fullScreenCheck() {
 }
 
 async function lockLandscape(){
-  fullScreenCheck() 
+  await fullScreenCheck() 
   await screen.orientation.lock('landscape');
 }
 
 async function unlock() {
-  fullScreenCheck();
+  await fullScreenCheck();
   await screen.orientation.unlock();
 }
 
 async function portrait(){
-  fullScreenCheck();
+  await fullScreenCheck();
   await screen.orientation.lock('portrait');
 }
 

--- a/index.html
+++ b/index.html
@@ -536,8 +536,7 @@
         button labelled "portrait" will also change it back to <a>portrait</a>.
       </p>
       <p>
-        The log shows the change in orientation type and angle, and the type of
-        event.
+        The log shows the change in orientation type and angle.
       </p>
       <pre class='example html'>
 &lt;script&gt;
@@ -547,40 +546,35 @@ async function fullScreenCheck() {
   } 
 }
 
-async function lockLandscape(){
-  await fullScreenCheck() 
-  await screen.orientation.lock('landscape');
-}
-
 async function unlock() {
   await fullScreenCheck();
   await screen.orientation.unlock();
 }
 
-async function portrait(){
+async function rotate() {
+  const rotate = document.getElementById("rotate");
   await fullScreenCheck();
-  await screen.orientation.lock('portrait');
+  const newOrientation = screen.orientation.type.startsWith("portrait")
+    ? "landscape"
+    : "portrait";
+  await screen.orientation.lock(newOrientation);
+  rotate.textContent = `Rotate to ${newOrientation}`;
 }
 
-const { type, angle } = screen.orientation
-function show(event) {
- console.log("Orientation type is " + screen.orientation.type);
- console.log("Orientation angle is " + screen.orientation.angle);
- console.log("Event Type is " + event.type)
+function show() {
+  const { type, angle } = screen.orientation;
+  console.log(`Orientation type is ${type} + angle is ${angle}`);
 }
 
 screen.orientation.addEventListener("change", show);
 window.addEventListener("load", show);
 &lt;/script&gt;
 
-&lt;button onclick="lockLandscape()"&gt;
-  Lock to landscape
+&lt;button onclick="rotate()"&gt;
+  Rotate
 &lt;/button&gt;
 &lt;button onclick='unlock()'&gt;
   Unlock
-&lt;/button&gt;
-&lt;button onclick="portrait()"&gt;
-  Portrait
 &lt;/button&gt;
 </pre>
       <p>


### PR DESCRIPTION
For review

I have changed this to be more specific to a phone because I think this makes the example clearer and is likely to be how people are testing out the example.  I have given it the specific aim of locking to landscape because I think this is also more useful.

(The full examples are available with a link for testing on phones at https://github.com/Johanna-hub/screen-orientation-examples)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Johanna-hub/screen-orientation/pull/133.html" title="Last updated on Jan 17, 2019, 1:24 PM UTC (4b2c2d4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-orientation/133/c904bd4...Johanna-hub:4b2c2d4.html" title="Last updated on Jan 17, 2019, 1:24 PM UTC (4b2c2d4)">Diff</a>