### PR TITLE
Editorial: Example 3

### DIFF
--- a/index.html
+++ b/index.html
@@ -572,10 +572,10 @@
 
 </pre>
       <p>
-        In this example for a mobile device, if the Screen
-        Orientation API is not supported, or the document is not fullscreen and
-        the screen orientation lock rejects, the user is alerted to rotate
-        their screen manually to landscape.
+        In this example for a mobile device, if the Screen Orientation API is
+        not supported, or the document is not fullscreen and the screen
+        orientation lock rejects, the user is alerted to rotate their screen
+        manually to landscape.
       </p>
       <pre class='example html'>
 &lt;script&gt;

--- a/index.html
+++ b/index.html
@@ -572,9 +572,10 @@
 
 </pre>
       <p>
-        In this example for a mobile device held in portrait, if the Screen Orientation API is not supported, or the
-        document is not fullscreen and the screen orientation lock rejects, the
-        user is alerted to rotate their screen manually to landscape.
+        In this example for a mobile device held in portrait, if the Screen
+        Orientation API is not supported, or the document is not fullscreen and
+        the screen orientation lock rejects, the user is alerted to rotate
+        their screen manually to landscape.
       </p>
       <pre class='example html'>
 &lt;script&gt;

--- a/index.html
+++ b/index.html
@@ -579,22 +579,31 @@
       <pre class='example html'>
 &lt;script&gt;
 function manualRotation() {
-  alert("Rotation to landscape complete");
+  alert("Thank you for rotating!");
 }
 
-function orientationChangeHandler() {
-  if (window.matchMedia("(orientation: portrait)").matches) {
-    return;
+function orientationChangeListener() {
+  const inPortrait = window.matchMedia("(orientation: portrait)");
+  function detectOrientation(e) {
+    if (e.matches) {
+      return;
+    } else {
+      window.removeEventListener(
+        "orientationchange",
+        orientationChangeListener
+      );
+      inPortrait.removeListener(detectOrientation);
+      manualRotation();
+    }
   }
-  window.removeEventListener("orientationchange", orientationChangeHandler);
-  manualRotation();
+  inPortrait.addListener(detectOrientation);
 }
 
 async function start() {
   try {
     await screen.orientation.lock("landscape");
   } catch {
-    window.addEventListener("orientationchange", orientationChangeHandler);
+    window.addEventListener("orientationchange", orientationChangeListener);
     alert("To start, please rotate your screen to landscape");
   }
 }

--- a/index.html
+++ b/index.html
@@ -592,10 +592,10 @@ async function rotate() {
   const matchLandscape = matchMedia("(orientation: landscape)");
   if (matchLandscape.matches) return start(); 
   addEventListener("orientationchange", function listener() {
-    matchPortrait.addListener(function mediaChange(e) {
+    matchLandscape.addListener(function mediaChange(e) {
       if (!e.matches) return; 
       removeEventListener("orientationchange", listener);
-      matchPortrait.removeListener(mediaChange);
+      matchLandscape.removeListener(mediaChange);
       start();
     });
   });

--- a/index.html
+++ b/index.html
@@ -572,9 +572,9 @@
 
 </pre>
       <p>
-        In this example if the Screen Orientation API is not supported, or the
+        In this example for a mobile device held in portrait, if the Screen Orientation API is not supported, or the
         document is not fullscreen and the screen orientation lock rejects, the
-        user is alerted to rotate their screen manually.
+        user is alerted to rotate their screen manually to landscape.
       </p>
       <pre class='example html'>
 &lt;script&gt;
@@ -582,27 +582,25 @@ function manualRotation() {
   alert("Thank you for rotating!");
 }
 
-function orientationChangeListener() {
-  const inPortrait = window.matchMedia("(orientation: portrait)");
-  function detectOrientation(e) {
-    if (e.matches) {
-      return;
-    } else {
-      window.removeEventListener(
-        "orientationchange",
-        orientationChangeListener
-      );
-      inPortrait.removeListener(detectOrientation);
-      manualRotation();
-    }
-  }
-  inPortrait.addListener(detectOrientation);
-}
-
 async function start() {
   try {
     await screen.orientation.lock("landscape");
   } catch {
+    const inPortrait = window.matchMedia("(orientation: portrait)");
+    function orientationChangeListener() {
+      function detectOrientation(e) {
+        if (e.matches) {
+          return;
+        }
+        window.removeEventListener(
+          "orientationchange",
+          orientationChangeListener
+        );
+        inPortrait.removeListener(detectOrientation);
+        manualRotation();
+      }
+      inPortrait.addListener(detectOrientation);
+    }
     window.addEventListener("orientationchange", orientationChangeListener);
     alert("To start, please rotate your screen to landscape");
   }

--- a/index.html
+++ b/index.html
@@ -572,39 +572,34 @@
 
 </pre>
       <p>
-        In this example for a mobile device held in portrait, if the Screen
+        In this example for a mobile device, if the Screen
         Orientation API is not supported, or the document is not fullscreen and
         the screen orientation lock rejects, the user is alerted to rotate
         their screen manually to landscape.
       </p>
       <pre class='example html'>
 &lt;script&gt;
-function manualRotation() {
-  alert("Thank you for rotating!");
+function start() {
+  /* Start application when in correct orientation */
 }
-
-async function start() {
+async function rotate() {
   try {
     await screen.orientation.lock("landscape");
-  } catch {
-    const inPortrait = window.matchMedia("(orientation: portrait)");
-    function orientationChangeListener() {
-      function detectOrientation(e) {
-        if (e.matches) {
-          return;
-        }
-        window.removeEventListener(
-          "orientationchange",
-          orientationChangeListener
-        );
-        inPortrait.removeListener(detectOrientation);
-        manualRotation();
-      }
-      inPortrait.addListener(detectOrientation);
-    }
-    window.addEventListener("orientationchange", orientationChangeListener);
-    alert("To start, please rotate your screen to landscape");
+    start();
+  } catch (err) {
+    console.error(err);
   }
+  const matchLandscape = matchMedia("(orientation: landscape)");
+  if (matchLandscape.matches) return start(); 
+  addEventListener("orientationchange", function listener() {
+    matchPortrait.addListener(function mediaChange(e) {
+      if (!e.matches) return; 
+      removeEventListener("orientationchange", listener);
+      matchPortrait.removeListener(mediaChange);
+      start();
+    });
+  });
+  alert("To start, please rotate your screen to landscape.");
 }
 &lt;/script&gt;
 &lt;button onclick='start();'&gt;

--- a/index.html
+++ b/index.html
@@ -572,31 +572,35 @@
 
 </pre>
       <p>
-        This example asks the user to manually rotate the device if the Screen
-        Orientation API is not available.
+        In this example if the Screen Orientation API
+         is not supported, or the document is not fullscreen and the screen orientation lock rejects, the user is alerted to rotate their screen manually. 
       </p>
-      <pre class='example js'>
+      <pre class='example html'>
 &lt;script&gt;
-  var start = function() {
-    screen.orientation.lock('landscape-primary').then(
-      startInternal,
-      function() {
-        alert('To start, rotate your screen to landscape.');
+function manualRotation() {
+  alert("Rotation to landscape complete");
+}
 
-        var orientationChangeHandler = function() {
-          if (!screen.orientation.type.startsWith('landscape')) {
-            return;
-          }
-          screen.orientation.removeEventListener('change', orientationChangeHandler);
-          startInternal();
-        }
-
-        screen.orientation.addEventListener('change', orientationChangeHandler);
-      });
+function orientationChangeHandler() {
+  if (window.matchMedia("(orientation: portrait)").matches) {
+    return;
   }
-  window.onload = start;
-&lt;/script&gt;
+  window.removeEventListener("orientationchange", orientationChangeHandler);
+  manualRotation();
+}
 
+async function start() {
+  try {
+    await screen.orientation.lock("landscape");
+  } catch {
+    window.addEventListener("orientationchange", orientationChangeHandler);
+    alert("To start, please rotate your screen to landscape");
+  }
+}
+&lt;/script&gt;
+&lt;button onclick='start();'&gt;
+  Start
+&lt;/button&gt;
 </pre>
     </section>
     <section>

--- a/index.html
+++ b/index.html
@@ -572,8 +572,9 @@
 
 </pre>
       <p>
-        In this example if the Screen Orientation API
-         is not supported, or the document is not fullscreen and the screen orientation lock rejects, the user is alerted to rotate their screen manually. 
+        In this example if the Screen Orientation API is not supported, or the
+        document is not fullscreen and the screen orientation lock rejects, the
+        user is alerted to rotate their screen manually.
       </p>
       <pre class='example html'>
 &lt;script&gt;


### PR DESCRIPTION
For review

- Main change from the original example, if screen orientation is not supported then `screen.orientation.type.startsWith` and `screen.orientation.add/remove.Event.Listener` should also not be used. 

- I changed the event listener to `window.add/removeEventListener("orientationchange")`.

- I used `window.matchMedia("(orientation: portrait)").matches` to check the orientation before displaying the final alert. However I have tested on iOS and android with differing results!  Available to test here https://johanna-hub.github.io/example-3/

- Safari and Chrome on iOS the example works completely fine.
- Chrome and Firefox on Android, the final completed alert only comes up once you have rotated back to portrait (same thing happens in devtools responsive mode on Chrome)

I think the matchMedia querylist needs a listener but then it gets too complicated!  So might be better to do `if(screen.width>screen.height)` just for the purposes of demonstration of the concept.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Johanna-hub/screen-orientation/pull/135.html" title="Last updated on Jan 22, 2019, 11:22 AM UTC (f3f1b5e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-orientation/135/c904bd4...Johanna-hub:f3f1b5e.html" title="Last updated on Jan 22, 2019, 11:22 AM UTC (f3f1b5e)">Diff</a>