### PR TITLE
Editorial: Examples section edits

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,7 +106,6 @@
       </ul>
       <section>
         <h2>
-
           Goals
         </h2>
         <ul>
@@ -124,17 +123,20 @@
           Examples
         </h2>
         <section>
-          <h2>Locking to a specific orientation and unlocking</h2>
-        <p>
-          In this example, clicking the "Lock" button makes a
-          request to go into fullscreen and then lock to the opposite orientation. If
-          the screen is not in default orientation, pressing the "Unlock" button
-          unlocks to its default orientation.  
-        </p>
-        <p>
-          The developer console logs the change in orientation type and angle.
-        </p>
-        <pre class='example html'>
+          <h2>
+            Locking to a specific orientation and unlocking
+          </h2>
+          <p>
+            In this example, clicking the "Lock" button makes a request to go
+            into fullscreen and then lock to the opposite orientation. If the
+            screen is not in default orientation, pressing the "Unlock" button
+            unlocks to its default orientation.
+          </p>
+          <p>
+            The developer console logs the change in orientation type and
+            angle.
+          </p>
+          <pre class='example html'>
   &lt;script&gt;
   function fullScreenCheck() {
     if (document.fullscreenElement) return;
@@ -185,14 +187,16 @@
     Unlock
   &lt;/button&gt;
   </pre>
-</section>
-<section>
-  <h2>Locking the screen before calling a function</h2>
-        <p>
-          This example waits to go into fullscreen, then locks to landscape before
-          calling <code>ready()</code>.
-        </p>
-        <pre class='example html'>
+        </section>
+        <section>
+          <h2>
+            Locking the screen before calling a function
+          </h2>
+          <p>
+            This example waits to go into fullscreen, then locks to landscape
+            before calling <code>ready()</code>.
+          </p>
+          <pre class='example html'>
   &lt;script&gt;
   function ready() {
     const { type } = screen.orientation;
@@ -209,16 +213,18 @@
     Start
   &lt;/button&gt;
   </pre>
-</section>
-<section>
-  <h2>Alerting the user if the Screen Orientation API is not supported</h2>
-        <p>
-          In this example, if the Screen Orientation API is
-          not supported, or the document is not fullscreen and the screen
-          orientation lock rejects, the user is alerted to rotate their screen
-          manually to landscape.
-        </p>
-        <pre class='example html'>
+        </section>
+        <section>
+          <h2>
+            Alerting the user if the Screen Orientation API is not supported
+          </h2>
+          <p>
+            In this example, if the Screen Orientation API is not supported, or
+            the document is not fullscreen and the screen orientation lock
+            rejects, the user is alerted to rotate their screen manually to
+            landscape.
+          </p>
+          <pre class='example html'>
   &lt;script&gt;
   function start() {
     /* Start application when in correct orientation */
@@ -247,7 +253,7 @@
     Start
   &lt;/button&gt;
   </pre>
-</section>
+        </section>
       </section>
     </section>
     <section data-dfn-for='Screen'>

--- a/index.html
+++ b/index.html
@@ -106,6 +106,7 @@
       </ul>
       <section>
         <h2>
+
           Goals
         </h2>
         <ul>
@@ -117,6 +118,136 @@
           update correspondingly.
           </li>
         </ul>
+      </section>
+      <section class='informative'>
+        <h2>
+          Examples
+        </h2>
+        <section>
+          <h2>Locking to a specific orientation and unlocking</h2>
+        <p>
+          In this example, clicking the "Lock" button makes a
+          request to go into fullscreen and then lock to the opposite orientation. If
+          the screen is not in default orientation, pressing the "Unlock" button
+          unlocks to its default orientation.  
+        </p>
+        <p>
+          The developer console logs the change in orientation type and angle.
+        </p>
+        <pre class='example html'>
+  &lt;script&gt;
+  function fullScreenCheck() {
+    if (document.fullscreenElement) return;
+    return document.documentElement.requestFullscreen();
+  }
+  
+  const lockButton = document.getElementById("lockBtn");
+
+  function btnOrientation() {
+    const btnOrientation = oppOrientation();
+    lockButton.textContent = `Lock to ${btnOrientation}`;
+  }
+  
+  function oppOrientation() {
+    const { type } = screen.orientation;
+    if (type.startsWith("portrait")) {
+      return "landscape";
+    }
+    return "portrait";
+  }
+
+  async function rotate() {
+    const rotateBtn = document.getElementById("rotateBtn");
+    try {
+      await fullScreenCheck();
+    } catch (err) {
+      console.error(err);
+    }
+    const newOrientation = oppOrientation();
+    await screen.orientation.lock(newOrientation);
+    btnOrientation();
+  }
+  
+  function show() {
+    const { type, angle } = screen.orientation;
+    console.log(`Orientation type is ${type} & angle is ${angle}.`);
+  }
+  
+  screen.orientation.addEventListener("change", show);
+  screen.orientation.addEventListener("change", btnOrientation);
+  window.addEventListener("load", show);
+  &lt;/script&gt;
+  
+  &lt;button onclick="rotate() id="lockBtn"&gt;
+    Lock
+  &lt;/button&gt;
+  &lt;button onclick='screen.orientation.unlock()'&gt;
+    Unlock
+  &lt;/button&gt;
+  </pre>
+</section>
+<section>
+  <h2>Locking the screen before calling a function</h2>
+        <p>
+          This example waits to go into fullscreen, then locks to landscape before
+          calling <code>ready()</code>.
+        </p>
+        <pre class='example html'>
+  &lt;script&gt;
+  function ready() {
+    const { type } = screen.orientation;
+    console.log("Fullscreen and locked to ${type}. Ready!");
+  }
+  
+  async function start() {
+    await document.body.requestFullscreen();
+    await screen.orientation.lock("landscape");
+    ready();
+  }
+  &lt;/script&gt;
+  &lt;button onclick='start()'&gt;
+    Start
+  &lt;/button&gt;
+  </pre>
+</section>
+<section>
+  <h2>Alerting the user if the Screen Orientation API is not supported</h2>
+        <p>
+          In this example, if the Screen Orientation API is
+          not supported, or the document is not fullscreen and the screen
+          orientation lock rejects, the user is alerted to rotate their screen
+          manually to landscape.
+        </p>
+        <pre class='example html'>
+  &lt;script&gt;
+  function start() {
+    /* Start application when in correct orientation */
+  }
+  async function rotate() {
+    try {
+      await screen.orientation.lock("landscape");
+      start();
+    } catch (err) {
+      console.error(err);
+    }
+    const matchLandscape = matchMedia("(orientation: landscape)");
+    if (matchLandscape.matches) return start(); 
+    addEventListener("orientationchange", function listener() {
+      matchLandscape.addListener(function mediaChange(e) {
+        if (!e.matches) return; 
+        removeEventListener("orientationchange", listener);
+        matchLandscape.removeListener(mediaChange);
+        start();
+      });
+    });
+    alert("To start, please rotate your screen to landscape.");
+  }
+  &lt;/script&gt;
+  &lt;button onclick='start();'&gt;
+    Start
+  &lt;/button&gt;
+  </pre>
+</section>
       </section>
     </section>
     <section data-dfn-for='Screen'>
@@ -571,115 +702,6 @@
           user needs to be advised of the orientation requirements.​
         </p>
       </section>
-    </section>
-    <section class='informative'>
-      <h2>
-        Examples
-      </h2>
-      <p>
-        In this example for a mobile device, clicking the Rotate button makes a
-        request to go fullscreen and then lock to the opposite orientation. If
-        the screen is not in default orientation, pressing the unlock button
-        reverts the screen orientation back.
-      </p>
-      <p>
-        The log shows the change in orientation type and angle.
-      </p>
-      <pre class='example html'>
-&lt;script&gt;
-async function fullScreenCheck() {
-  if (document.fullscreenElement === null) {
-    await document.body.requestFullscreen();
-  }
-}
-
-async function unlock() {
-  await fullScreenCheck();
-  await screen.orientation.unlock();
-}
-
-async function rotate() {
-  const rotateBtn = document.getElementById("rotateBtn");
-  await fullScreenCheck();
-  const newOrientation = screen.orientation.type.startsWith("portrait")
-    ? "landscape"
-    : "portrait";
-  await screen.orientation.lock(newOrientation);
-  rotateBtn.textContent = `Rotate to ${newOrientation}`;
-}
-
-function show() {
-  const { type, angle } = screen.orientation;
-  console.log(`Orientation type is ${type} & angle is ${angle}`);
-}
-
-screen.orientation.addEventListener("change", show);
-window.addEventListener("load", show);
-&lt;/script&gt;
-
-&lt;button onclick="rotate() id="rotateBtn"&gt;
-  Rotate
-&lt;/button&gt;
-&lt;button onclick='unlock()'&gt;
-  Unlock
-&lt;/button&gt;
-</pre>
-      <p>
-        This example waits for fullscreen, then locks to landscape before
-        calling <code>ready()</code>.
-      </p>
-      <pre class='example html'>
-&lt;script&gt;
-function ready() {
-  const { type } = screen.orientation;
-  console.log("Fullscreen and locked to ${type}. Ready!");
-}
-
-async function start() {
-  await document.body.requestFullscreen();
-  await screen.orientation.lock("landscape");
-  ready();
-}
-&lt;/script&gt;
-&lt;button onclick='start();'&gt;
-  Start
-&lt;/button&gt;
-</pre>
-      <p>
-        In this example for a mobile device, if the Screen Orientation API is
-        not supported, or the document is not fullscreen and the screen
-        orientation lock rejects, the user is alerted to rotate their screen
-        manually to landscape.
-      </p>
-      <pre class='example html'>
-&lt;script&gt;
-function start() {
-  /* Start application when in correct orientation */
-}
-async function rotate() {
-  try {
-    await screen.orientation.lock("landscape");
-    start();
-  } catch (err) {
-    console.error(err);
-  }
-  const matchLandscape = matchMedia("(orientation: landscape)");
-  if (matchLandscape.matches) return start(); 
-  addEventListener("orientationchange", function listener() {
-    matchLandscape.addListener(function mediaChange(e) {
-      if (!e.matches) return; 
-      removeEventListener("orientationchange", listener);
-      matchLandscape.removeListener(mediaChange);
-      start();
-    });
-  });
-  alert("To start, please rotate your screen to landscape.");
-}
-&lt;/script&gt;
-&lt;button onclick='start();'&gt;
-  Start
-&lt;/button&gt;
-</pre>
     </section>
     <section>
       <h2>

--- a/index.html
+++ b/index.html
@@ -180,7 +180,7 @@
   });
   &lt;/script&gt;
   
-  &lt;button onclick="rotate() id="button"&gt;
+  &lt;button onclick="rotate(this)" id="button"&gt;
     Lock
   &lt;/button&gt;
   &lt;button onclick='screen.orientation.unlock()'&gt;

--- a/index.html
+++ b/index.html
@@ -143,31 +143,25 @@
     return document.documentElement.requestFullscreen();
   }
   
-  const lockButton = document.getElementById("lockBtn");
-
-  function btnOrientation() {
-    const btnOrientation = oppOrientation();
-    lockButton.textContent = `Lock to ${btnOrientation}`;
+  function updateDetails(lockButton) {
+    const buttonOrientation = getOppositeOrientation();
+    lockButton.textContent = `Lock to ${buttonOrientation}`;
   }
   
-  function oppOrientation() {
+  function getOppositeOrientation() {
     const { type } = screen.orientation;
-    if (type.startsWith("portrait")) {
-      return "landscape";
-    }
-    return "portrait";
+    return type.startsWith("portrait") ? "landscape" : "portrait";
   }
-
-  async function rotate() {
-    const rotateBtn = document.getElementById("rotateBtn");
+  
+  async function rotate(lockButton) {
     try {
       await fullScreenCheck();
     } catch (err) {
       console.error(err);
     }
-    const newOrientation = oppOrientation();
+    const newOrientation = getOppositeOrientation();
     await screen.orientation.lock(newOrientation);
-    btnOrientation();
+    updateDetails(lockButton);
   }
   
   function show() {
@@ -175,12 +169,18 @@
     console.log(`Orientation type is ${type} & angle is ${angle}.`);
   }
   
-  screen.orientation.addEventListener("change", show);
-  screen.orientation.addEventListener("change", btnOrientation);
-  window.addEventListener("load", show);
+  screen.orientation.addEventListener("change", () => {
+    show();
+    updateDetails(document.getElementById("button"));
+  });
+  
+  window.addEventListener("load", () => {
+    show();
+    updateDetails(document.getElementById("button"));
+  });
   &lt;/script&gt;
   
-  &lt;button onclick="rotate() id="lockBtn"&gt;
+  &lt;button onclick="rotate() id="button"&gt;
     Lock
   &lt;/button&gt;
   &lt;button onclick='screen.orientation.unlock()'&gt;


### PR DESCRIPTION
In testing Example 1 with the discussed revisions, I came across some issues so a lot of it has been rewritten, so please give feedback!

- we changed document.documentElement.requestFullScreen() to document.body.requestFullScreen() for reasons of length.  This actually makes the whole screen go black so I've changed it back to solve that problem
- The way I had written the example before, the button text only changed when it was pressed.  I have now changed it so that it also changes on user rotation (otherwise user could rotate manually to portrait and it would still say lock to portrait).  It also displays the opposite orientation on load.

Other example edits have been completed, sections/titles, edits and moving it up to Introduction section.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Johanna-hub/screen-orientation/pull/137.html" title="Last updated on Jan 29, 2019, 11:34 AM UTC (e833f95)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-orientation/137/98b4058...Johanna-hub:e833f95.html" title="Last updated on Jan 29, 2019, 11:34 AM UTC (e833f95)">Diff</a>