### PR TITLE
Editorial: 2.1 Orientation attribute, 3. Screen Orientation and enums

### DIFF
--- a/index.html
+++ b/index.html
@@ -162,38 +162,34 @@
             readonly attribute unsigned short angle;
             attribute EventHandler onchange;
           };
+
+          enum OrientationLockType {
+            "any",
+            "natural",
+            "landscape",
+            "portrait",
+            "portrait-primary",
+            "portrait-secondary",
+            "landscape-primary",
+            "landscape-secondary"
+          };
+
+          enum OrientationType {
+            "portrait-primary",
+            "portrait-secondary" 
+            "landscape-primary",
+            "landscape-secondary"
+          };
         </pre>
-      <section>
-        <h2>
-          <dfn>OrientationType</dfn> enum
-        </h2>
-        <pre class='idl'>
-                  enum OrientationType {
-                    "portrait-primary",
-                    "portrait-secondary",
-                    "landscape-primary",
-                    "landscape-secondary"
-                  };
-                </pre>
-      </section>
-      <section data-link-for="OrientationLockType" data-dfn-for=
-      "OrientationLockType">
-        <h2>
-          <dfn>OrientationLockType</dfn> enum
-        </h2>
-        <pre class='idl'>
-                  enum OrientationLockType {
-                    "any",
-                    "natural",
-                    "landscape",
-                    "portrait",
-                    "portrait-primary",
-                    "portrait-secondary",
-                    "landscape-primary",
-                    "landscape-secondary"
-                  };
-                </pre>
-      </section>
+        <p>
+          The <dfn>OrientationLockType</dfn> enum represents 
+          the screen orientations to which a screen can be locked.
+        </p>
+        <p>
+          On the other hand, <dfn>OrientationType</dfn> enum 
+          represent the actual current screen orientation that the screen is in irrespective
+          of which lock is applied. 
+        </p>
       <section>
         <h2>
           <dfn>lock()</dfn> method

--- a/index.html
+++ b/index.html
@@ -180,7 +180,7 @@
             "landscape-primary",
             "landscape-secondary"
           };
-        </pre>
+      </pre>
       <p data-dfn-for="OrientationLockType">
         The <dfn>OrientationLockType</dfn> enum represents the screen
         orientations to which a screen can be locked: the "<dfn>any</dfn>" enum

--- a/index.html
+++ b/index.html
@@ -320,10 +320,11 @@
           orientations or the current orientation when the application starts.
         </p>
         <p>
-          The <a>screen orientation values table</a> presents the possible orientation types: <dfn>portrait-primary</dfn>, 
-          <dfn>portrait-secondary</dfn>, <dfn>landscape-primary</dfn>
-          and <dfn>landscape-secondary</dfn>.  The table shows the primary and secondary values 
-          that are determined by the device's natural
+          The <a>screen orientation values table</a> presents the possible
+          orientation types: <dfn>portrait-primary</dfn>,
+          <dfn>portrait-secondary</dfn>, <dfn>landscape-primary</dfn> and
+          <dfn>landscape-secondary</dfn>. The table shows the primary and
+          secondary values that are determined by the device's natural
           orientation and the possibilities available to the <a>user agent</a>
           for setting the other primary and secondary orientation values.
         </p>
@@ -336,8 +337,7 @@
           <thead>
             <tr>
               <th>
-                <dfn>Natural</dfn>
-                Orientation
+                <dfn>Natural</dfn> Orientation
               </th>
               <th>
                 Primary Orientation 1

--- a/index.html
+++ b/index.html
@@ -176,24 +176,31 @@
 
           enum OrientationType {
             "portrait-primary",
-            "portrait-secondary" 
+            "portrait-secondary", 
             "landscape-primary",
             "landscape-secondary"
           };
         </pre>
-      <p>
+      <p data-dfn-for="OrientationLockType">
         The <dfn>OrientationLockType</dfn> enum represents the screen
-        orientations to which a screen can be locked. The values to which a
-        screen can be locked are: <a>any</a>, <a>natural</a>, <a>landscape</a>,
-        <a>portrait</a>, <a>portrait-primary</a>, <a>portrait-secondary</a>,
-        <a>landscape-primary</a>, <a>landscape-secondary</a>.
+        orientations to which a screen can be locked. The screen can be locked to the following enum values: 
+        the "<dfn>any</dfn>" enum value represents the <a>any</a> orientation, 
+        the "<dfn>natural</dfn>" enum represents the <a>natural</a> orientation, 
+        the "<dfn>landscape</dfn>" enum represents the <a>landscape</a> orientation,
+        the "<dfn>portrait</dfn>" enum represents the <a>portrait</a> orientation,
+        the "<dfn>portrait-primary</dfn>" enum represents the <a>portrait-primary</a> orientation,
+        the "<dfn>portrait-secondary</dfn>" enum represents the <a>portrait-secondary</a> orientation,
+        the "<dfn>landscape-primary</dfn>" enum represents the <a>landscape-primary</a> orientation,
+        the "<dfn>landscape-secondary</dfn>" enum represents the <a>landscape-secondary</a> orientation.
       </p>
-      <p>
-        On the other hand, <dfn>OrientationType</dfn> enum represent the actual
+      <p data-dfn-for="OrientationType">
+        The <dfn>OrientationType</dfn> enum represents the actual
         current screen orientation that the screen is in irrespective of which
         lock is applied. The current screen orientation can be:
-        <a>portrait-primary</a>, <a>portrait-secondary</a>,
-        <a>landscape-primary</a>, <a>landscape-secondary</a>.
+        the "<dfn>portrait-primary</dfn>" enum represents the <a>portrait-primary</a> orientation,
+        the "<dfn>portrait-secondary</dfn>" enum represents the <a>portrait-secondary</a> orientation,
+        the "<dfn>landscape-primary</dfn>" enum represents the <a>landscape-primary</a> orientation,
+        the "<dfn>landscape-secondary</dfn>" enum represents the <a>landscape-secondary</a> orientation.
       </p>
       <section>
         <h2>
@@ -245,12 +252,12 @@
         <div class='note'>
           <p>
             <a>angle</a> indicates how far the user has turned the device
-            counterclockwise from the natural orientation. When the device is
+            counterclockwise from the <a>natural</a> orientation. When the device is
             rotated 90° counterclockwise, the screen compensates by rotating
             90° clockwise, so <a>angle</a> returns <code>90</code>.
           </p>
           <p>
-            If the device is rotated 90° clockwise from its natural
+            If the device is rotated 90° clockwise from its <a>natural</a>
             orientation, the screen compensates by rotating 90°
             counterclockwise, so <a>angle</a> returns <code>270</code>.
           </p>
@@ -289,41 +296,38 @@
         <h2>
           Screen orientation types and locks
         </h2>
-        <p>
-          If the screen width is greater than the screen height the <a>current
-          orientation type</a> and <a>orientation lock</a> (if the screen is
-          locked) will be either <dfn>landscape-primary</dfn> or
-          <dfn>landscape-secondary</dfn>.
+        <p><dfn>landscape-primary</dfn> is an orientation where the screen width is greater than the screen height.  If the device's natural orientation is landscape, 
+          then it is in landscape-primary when held in that position.  If the device's natural orientation is portrait, the <a>user agent</a> sets landscape-primary 
+          from the two options as shown <a>screen orientation values table</a>.
         </p>
         <p>
-          If the screen width is less than or equal to the screen height, the
-          <a>current orientation type</a> and <a>orientation lock</a> (if the
-          screen is locked) will be either <dfn>portrait-primary</dfn> or
-          <dfn>portrait-secondary</dfn>.
+          <dfn>landscape-secondary</dfn> is an orientation where the screen width is greater than the screen height.  If the device's natural orientation is landscape, it is in landscape-secondary 
+          when rotated 180º from it's natural orientation.  If the device's natural orientation is portrait, the <a>user agent</a> sets landscape-secondary 
+          from the two options as shown in the <a>screen orientation values table</a>.
         </p>
         <p>
-          See the <a>screen orientation values table</a> for clarification on
-          how the <a>user agent</a> determines primary and secondary values.
+          <dfn>portrait-primary</dfn> is an orientation where the screen width is less than or equal to the screen height.  If the device's natural orientation is portrait, then it 
+          is in portrait-primary when held in that position.  If the device's natural orientation is landscape, the <a>user agent</a> sets portrait-primary from the two options as shown in the 
+          <a>screen orientation values table</a>.
         </p>
         <p>
-          Depending on platform convention locking the screen to
-          <dfn>landscape</dfn> can represent landscape-primary,
-          landscape-secondary or both.
+          <dfn>portrait-secondary</dfn> is an orientation where the screen width is less than or equal to the screen height.  If the device's natural orientation is portrait, then it 
+          is in portrait-secondary when rotated 180º from it's natural position.  If the device's natural orientation is landscape, the <a>user agent</a> sets portrait-secondary 
+          from the two options as shown in the <a>screen orientation values table</a>.
         </p>
         <p>
-          Depending on platform convention locking the screen to
-          <dfn>portrait</dfn> can represent portrait-primary,
-          portrait-secondary or both.
+          <dfn>portrait</dfn> is an orientation where the screen width is less than or equal to the screen height and depending on platform convention locking the screen to
+          portrait can represent portrait-primary, portrait-secondary or both.
         </p>
         <p>
-          Locking the screen to <dfn>natural</dfn> refers to either
-          portrait-primary or landscape-primary depending on the device's usual
-          orientation.
+          <dfn>landscape</dfn> is an orientation where the screen width is greater than the screen height and depending on platform convention locking the screen to landscape can 
+          represent landscape-primary, landscape-secondary or both.
         </p>
         <p>
-          Locking the screen to <dfn>any</dfn> means the screen can be locked
-          to any one of portrait-primary, portrait-secondary, landscape-primary
-          and landscape-secondary.
+          <dfn>natural</dfn> is an orientation that refers to either portrait-primary or landscape-primary depending on the device's usual orientation.
+        </p>
+        <p>
+          <dfn>any</dfn> is an orientation that means the screen can be locked to any one of portrait-primary, portrait-secondary, landscape-primary and landscape-secondary.
         </p>
       </section>
       <section data-dfn-for='OrientationType' data-link-for="OrientationType">
@@ -345,12 +349,12 @@
           that for any given type, there will be a specific angle associated.
         </p>
         <p>
-          One primary orientation will always be determined by the natural
+          One primary orientation will always be determined by the <a>natural</a>
           orientation of the device and this will then determine the secondary
           value of its related orientation.
         </p>
         <p>
-          For example a device held in its natural portrait orientation would
+          For example a device held in its natural <a>portrait</a> orientation would
           have a current orientation of <a>portrait-primary</a> and its
           <a>portrait-secondary</a> orientation would be its position when
           rotated 180°.
@@ -366,7 +370,7 @@
           orientation types: <a>portrait-primary</a>,
           <a>portrait-secondary</a>, <a>landscape-primary</a> and
           <a>landscape-secondary</a>. The table shows the primary and secondary
-          values that are determined by the device's natural orientation and
+          values that are determined by the device's <a>natural</a> orientation and
           the possibilities available to the <a>user agent</a> for setting the
           other primary and secondary orientation values.
         </p>
@@ -460,7 +464,7 @@
             would be wrong given that a device might have <code>90</code> and
             <code>270</code> as the angles for <code>landscape</code> types but
             another device will have <code>0</code> and <code>180</code>,
-            depending on its natural orientation. Instead, it is recommended to
+            depending on its <a>natural</a> orientation. Instead, it is recommended to
             check during runtime the relationship between angle and type.
           </p>
         </div>
@@ -753,7 +757,7 @@ async function rotate() {
           </li>
           <li>Set the <a>document</a>'s <a>current orientation angle</a> to the
           clockwise angle in degrees between the orientation of the viewport as
-          it is drawn and the natural orientation of the device (i.e., the top
+          it is drawn and the <a>natural</a>orientation of the device (i.e., the top
           of the physical screen). This is the opposite of the physical
           rotation. In other words, if a device is turned 90 degrees on the
           right, the <a>current orientation angle</a> would be 270 degrees.

--- a/index.html
+++ b/index.html
@@ -162,7 +162,7 @@
             readonly attribute unsigned short angle;
             attribute EventHandler onchange;
           };
-
+        
           enum OrientationLockType {
             "any",
             "natural",
@@ -183,12 +183,15 @@
         </pre>
         <p>
           The <dfn>OrientationLockType</dfn> enum represents 
-          the screen orientations to which a screen can be locked.
+          the screen orientations to which a screen can be locked.  The values to which a screen can be locked are: <a>any</a>, <a>natural</a>, 
+          <a>landscape</a>, <a>portrait</a>, <a>portrait-primary</a>, <a>portrait-secondary</a>, <a>landscape-primary</a>, 
+          <a>landscape-secondary</a>.
         </p>
         <p>
           On the other hand, <dfn>OrientationType</dfn> enum 
           represent the actual current screen orientation that the screen is in irrespective
-          of which lock is applied. 
+          of which lock is applied. The current screen orientation can be: <a>portrait-primary</a>, <a>portrait-secondary</a>, 
+          <a>landscape-primary</a>, <a>landscape-secondary</a>.
         </p>
       <section>
         <h2>
@@ -280,6 +283,33 @@
         initially set to <code>null</code>, which is a promise whose associated
         operation is to lock the screen orientation.
       </p>
+      <section>
+        <h2>Screen orientation types and locks</h2>
+        <p>
+          If the screen width is greater than the screen height the <a>current orientation type</a> and <a>orientation lock</a> (if the screen is locked) will be either <dfn>landscape-primary</dfn> or
+          <dfn>landscape-secondary</dfn>.  
+        </p>
+        <p>
+          If the screen width is less than or equal to the screen height, the <a>current orientation type</a> and <a>orientation lock</a> (if the screen is locked) will be either <dfn>portrait-primary</dfn> or
+          <dfn>portrait-secondary</dfn>.
+        </p>
+        <p>
+          See the <a>screen orientation values table</a> for clarification on how the <a>user agent</a> determines primary and secondary values.
+        </p>
+        <p>
+          Depending on platform convention locking the screen to <dfn>landscape</dfn> can represent landscape-primary, landscape-secondary or both.
+        </p>
+        <p>
+          Depending on platform convention locking the screen to <dfn>portrait</dfn> can represent portrait-primary, portrait-secondary or both.
+        </p>
+        <p>
+          Locking the screen to <dfn>natural</dfn> refers to either portrait-primary or landscape-primary depending on the device's usual orientation.
+        </p>
+        <p>
+          Locking the screen to <dfn>any</dfn> means the screen can be locked to any one of portrait-primary, portrait-secondary, landscape-primary and landscape-secondary.
+        </p>
+        
+      </section>
       <section data-dfn-for='OrientationType' data-link-for="OrientationType">
         <h2>
           Reading the screen orientation
@@ -317,9 +347,9 @@
         </p>
         <p>
           The <a>screen orientation values table</a> presents the possible
-          orientation types: <dfn>portrait-primary</dfn>,
-          <dfn>portrait-secondary</dfn>, <dfn>landscape-primary</dfn> and
-          <dfn>landscape-secondary</dfn>. The table shows the primary and
+          orientation types: <a>portrait-primary</a>,
+          <a>portrait-secondary</a>, <a>landscape-primary</a> and
+          <a>landscape-secondary</a>. The table shows the primary and
           secondary values that are determined by the device's natural
           orientation and the possibilities available to the <a>user agent</a>
           for setting the other primary and secondary orientation values.
@@ -329,11 +359,11 @@
             The <dfn>screen orientation values table</dfn>
           </caption>
         </table>
-        <table data-dfn-for="OrientationLockType">
+        <table>
           <thead>
             <tr>
               <th>
-                <dfn>Natural</dfn> Orientation
+                <a>Natural</a> Orientation
               </th>
               <th>
                 Primary Orientation 1
@@ -352,30 +382,30 @@
           <tbody>
             <tr>
               <td>
-                <dfn>Portrait</dfn>
+                <a>Portrait</a>
               </td>
               <td>
-                <dfn>portrait-primary</dfn><br>
+                <a>portrait-primary</a><br>
                 <a data-link-for="ScreenOrientation">Angle</a> <code>0</code>
               </td>
               <td>
-                <dfn>portrait-secondary</dfn><br>
+                <a>portrait-secondary</a><br>
                 <a data-link-for="ScreenOrientation">Angle</a> <code>180</code>
               </td>
               <td>
-                <dfn>landscape-primary</dfn><br>
+                <a>landscape-primary</a><br>
                 <a>User agent</a> to set at either <a data-link-for=
                 "ScreenOrientation">Angle</a> <code>90</code> or
                 <a data-link-for="ScreenOrientation">Angle</a> <code>270</code>
               </td>
               <td>
-                <dfn>landscape-secondary</dfn><br>
+                <a>landscape-secondary</a><br>
                 Set at the angle not used for landscape-primary
               </td>
             </tr>
             <tr>
               <td>
-                <dfn>Landscape</dfn>
+                <a>Landscape</a>
               </td>
               <td>
                 <a>landscape-primary</a><br>
@@ -801,7 +831,7 @@ async function rotate() {
                 as the associated <a>current orientation angle</a> is 0.
               </dd>
               <dt>
-                <dfn data-dfn-for='OrientationLockType'>any</dfn>
+                <a>any</a>
               </dt>
               <dd>
                 Append <code>portrait-primary</code>,
@@ -956,7 +986,7 @@ async function rotate() {
               </li>
               <li>If the orientation change was triggered by a user gesture
               such as the user turning the device, as opposed to a call to <a>
-                lock</a>, the <a>task</a> MUST be annotated with <code>process
+                lock()</a>, the <a>task</a> MUST be annotated with <code>process
                 user orientation change</code> when running the next step.
               </li>
               <li>
@@ -998,7 +1028,7 @@ async function rotate() {
               </li>
               <li>If the orientation change was triggered by a user gesture
               such as the user turning the device, as opposed to a call to <a>
-                lock</a>, the <a>task</a> MUST be annotated with <code>process
+                lock()</a>, the <a>task</a> MUST be annotated with <code>process
                 user orientation change</code> when running the next step.
               </li>
               <li>

--- a/index.html
+++ b/index.html
@@ -332,7 +332,7 @@
           <dfn>Portrait-secondary</dfn> is an orientation where the screen
           width is less than or equal to the screen height. If the device's
           natural orientation is portrait, then it is in portrait-secondary
-          when rotated 180º from it's natural position. If the device's natural
+          when rotated 180º from its natural position. If the device's natural
           orientation is landscape, the <a>user agent</a> sets
           portrait-secondary from the two options as shown in the <a>screen
           orientation values table</a>.

--- a/index.html
+++ b/index.html
@@ -183,8 +183,7 @@
         </pre>
       <p data-dfn-for="OrientationLockType">
         The <dfn>OrientationLockType</dfn> enum represents the screen
-        orientations to which a screen can be locked. The screen can be locked
-        to the following enum values: the "<dfn>any</dfn>" enum value
+        orientations to which a screen can be locked: the "<dfn>any</dfn>" enum value
         represents the <a>any</a> orientation, the "<dfn>natural</dfn>" enum
         represents the <a>natural</a> orientation, the "<dfn>landscape</dfn>"
         enum represents the <a>landscape</a> orientation, the
@@ -194,20 +193,20 @@
         "<dfn>portrait-secondary</dfn>" enum represents the
         <a>portrait-secondary</a> orientation, the
         "<dfn>landscape-primary</dfn>" enum represents the
-        <a>landscape-primary</a> orientation, the
+        <a>landscape-primary</a> orientation and the
         "<dfn>landscape-secondary</dfn>" enum represents the
         <a>landscape-secondary</a> orientation.
       </p>
       <p data-dfn-for="OrientationType">
         The <dfn>OrientationType</dfn> enum represents the actual current
         screen orientation that the screen is in irrespective of which lock is
-        applied. The current screen orientation can be: the
+        applied: the
         "<dfn>portrait-primary</dfn>" enum represents the
         <a>portrait-primary</a> orientation, the
         "<dfn>portrait-secondary</dfn>" enum represents the
         <a>portrait-secondary</a> orientation, the
         "<dfn>landscape-primary</dfn>" enum represents the
-        <a>landscape-primary</a> orientation, the
+        <a>landscape-primary</a> orientation and the
         "<dfn>landscape-secondary</dfn>" enum represents the
         <a>landscape-secondary</a> orientation.
       </p>

--- a/index.html
+++ b/index.html
@@ -181,18 +181,20 @@
             "landscape-secondary"
           };
         </pre>
-        <p>
-          The <dfn>OrientationLockType</dfn> enum represents 
-          the screen orientations to which a screen can be locked.  The values to which a screen can be locked are: <a>any</a>, <a>natural</a>, 
-          <a>landscape</a>, <a>portrait</a>, <a>portrait-primary</a>, <a>portrait-secondary</a>, <a>landscape-primary</a>, 
-          <a>landscape-secondary</a>.
-        </p>
-        <p>
-          On the other hand, <dfn>OrientationType</dfn> enum 
-          represent the actual current screen orientation that the screen is in irrespective
-          of which lock is applied. The current screen orientation can be: <a>portrait-primary</a>, <a>portrait-secondary</a>, 
-          <a>landscape-primary</a>, <a>landscape-secondary</a>.
-        </p>
+      <p>
+        The <dfn>OrientationLockType</dfn> enum represents the screen
+        orientations to which a screen can be locked. The values to which a
+        screen can be locked are: <a>any</a>, <a>natural</a>, <a>landscape</a>,
+        <a>portrait</a>, <a>portrait-primary</a>, <a>portrait-secondary</a>,
+        <a>landscape-primary</a>, <a>landscape-secondary</a>.
+      </p>
+      <p>
+        On the other hand, <dfn>OrientationType</dfn> enum represent the actual
+        current screen orientation that the screen is in irrespective of which
+        lock is applied. The current screen orientation can be:
+        <a>portrait-primary</a>, <a>portrait-secondary</a>,
+        <a>landscape-primary</a>, <a>landscape-secondary</a>.
+      </p>
       <section>
         <h2>
           <dfn>lock()</dfn> method
@@ -284,31 +286,45 @@
         operation is to lock the screen orientation.
       </p>
       <section>
-        <h2>Screen orientation types and locks</h2>
+        <h2>
+          Screen orientation types and locks
+        </h2>
         <p>
-          If the screen width is greater than the screen height the <a>current orientation type</a> and <a>orientation lock</a> (if the screen is locked) will be either <dfn>landscape-primary</dfn> or
-          <dfn>landscape-secondary</dfn>.  
+          If the screen width is greater than the screen height the <a>current
+          orientation type</a> and <a>orientation lock</a> (if the screen is
+          locked) will be either <dfn>landscape-primary</dfn> or
+          <dfn>landscape-secondary</dfn>.
         </p>
         <p>
-          If the screen width is less than or equal to the screen height, the <a>current orientation type</a> and <a>orientation lock</a> (if the screen is locked) will be either <dfn>portrait-primary</dfn> or
+          If the screen width is less than or equal to the screen height, the
+          <a>current orientation type</a> and <a>orientation lock</a> (if the
+          screen is locked) will be either <dfn>portrait-primary</dfn> or
           <dfn>portrait-secondary</dfn>.
         </p>
         <p>
-          See the <a>screen orientation values table</a> for clarification on how the <a>user agent</a> determines primary and secondary values.
+          See the <a>screen orientation values table</a> for clarification on
+          how the <a>user agent</a> determines primary and secondary values.
         </p>
         <p>
-          Depending on platform convention locking the screen to <dfn>landscape</dfn> can represent landscape-primary, landscape-secondary or both.
+          Depending on platform convention locking the screen to
+          <dfn>landscape</dfn> can represent landscape-primary,
+          landscape-secondary or both.
         </p>
         <p>
-          Depending on platform convention locking the screen to <dfn>portrait</dfn> can represent portrait-primary, portrait-secondary or both.
+          Depending on platform convention locking the screen to
+          <dfn>portrait</dfn> can represent portrait-primary,
+          portrait-secondary or both.
         </p>
         <p>
-          Locking the screen to <dfn>natural</dfn> refers to either portrait-primary or landscape-primary depending on the device's usual orientation.
+          Locking the screen to <dfn>natural</dfn> refers to either
+          portrait-primary or landscape-primary depending on the device's usual
+          orientation.
         </p>
         <p>
-          Locking the screen to <dfn>any</dfn> means the screen can be locked to any one of portrait-primary, portrait-secondary, landscape-primary and landscape-secondary.
+          Locking the screen to <dfn>any</dfn> means the screen can be locked
+          to any one of portrait-primary, portrait-secondary, landscape-primary
+          and landscape-secondary.
         </p>
-        
       </section>
       <section data-dfn-for='OrientationType' data-link-for="OrientationType">
         <h2>
@@ -349,10 +365,10 @@
           The <a>screen orientation values table</a> presents the possible
           orientation types: <a>portrait-primary</a>,
           <a>portrait-secondary</a>, <a>landscape-primary</a> and
-          <a>landscape-secondary</a>. The table shows the primary and
-          secondary values that are determined by the device's natural
-          orientation and the possibilities available to the <a>user agent</a>
-          for setting the other primary and secondary orientation values.
+          <a>landscape-secondary</a>. The table shows the primary and secondary
+          values that are determined by the device's natural orientation and
+          the possibilities available to the <a>user agent</a> for setting the
+          other primary and secondary orientation values.
         </p>
         <table>
           <caption>
@@ -986,8 +1002,9 @@ async function rotate() {
               </li>
               <li>If the orientation change was triggered by a user gesture
               such as the user turning the device, as opposed to a call to <a>
-                lock()</a>, the <a>task</a> MUST be annotated with <code>process
-                user orientation change</code> when running the next step.
+                lock()</a>, the <a>task</a> MUST be annotated with
+                <code>process user orientation change</code> when running the
+                next step.
               </li>
               <li>
                 <a>Fire an event</a> named <code>change</code> at
@@ -1028,8 +1045,9 @@ async function rotate() {
               </li>
               <li>If the orientation change was triggered by a user gesture
               such as the user turning the device, as opposed to a call to <a>
-                lock()</a>, the <a>task</a> MUST be annotated with <code>process
-                user orientation change</code> when running the next step.
+                lock()</a>, the <a>task</a> MUST be annotated with
+                <code>process user orientation change</code> when running the
+                next step.
               </li>
               <li>
                 <a>Fire an event</a> named <code>change</code> at the

--- a/index.html
+++ b/index.html
@@ -320,8 +320,10 @@
           orientations or the current orientation when the application starts.
         </p>
         <p>
-          The <a>screen orientation values table</a> presents the primary and
-          secondary values that are determined by the device's natural
+          The <a>screen orientation values table</a> presents the possible orientation types: <dfn>portrait-primary</dfn>, 
+          <dfn>portrait-secondary</dfn>, <dfn>landscape-primary</dfn>
+          and <dfn>landscape-secondary</dfn>.  The table shows the primary and secondary values 
+          that are determined by the device's natural
           orientation and the possibilities available to the <a>user agent</a>
           for setting the other primary and secondary orientation values.
         </p>
@@ -330,11 +332,11 @@
             The <dfn>screen orientation values table</dfn>
           </caption>
         </table>
-        <table data-dfn-for="OrientationType">
+        <table data-dfn-for="OrientationLockType">
           <thead>
             <tr>
               <th>
-                <dfn data-dfn-for="OrientationLockType">Natural</dfn>
+                <dfn>Natural</dfn>
                 Orientation
               </th>
               <th>
@@ -354,7 +356,7 @@
           <tbody>
             <tr>
               <td>
-                <dfn data-dfn-for="OrientationLockType">Portrait</dfn>
+                <dfn>Portrait</dfn>
               </td>
               <td>
                 <dfn>portrait-primary</dfn><br>
@@ -377,7 +379,7 @@
             </tr>
             <tr>
               <td>
-                <dfn data-dfn-for="OrientationLockType">Landscape</dfn>
+                <dfn>Landscape</dfn>
               </td>
               <td>
                 <a>landscape-primary</a><br>

--- a/index.html
+++ b/index.html
@@ -193,7 +193,7 @@
         "<dfn>portrait-secondary</dfn>" enum represents the
         <a>portrait-secondary</a> orientation, the
         "<dfn>landscape-primary</dfn>" enum represents the
-        <a>landscape-primary</a> orientation and the
+        <a>landscape-primary</a> orientation, and the
         "<dfn>landscape-secondary</dfn>" enum represents the
         <a>landscape-secondary</a> orientation.
       </p>
@@ -205,7 +205,7 @@
         "<dfn>portrait-secondary</dfn>" enum represents the
         <a>portrait-secondary</a> orientation, the
         "<dfn>landscape-primary</dfn>" enum represents the
-        <a>landscape-primary</a> orientation and the
+        <a>landscape-primary</a> orientation, and the
         "<dfn>landscape-secondary</dfn>" enum represents the
         <a>landscape-secondary</a> orientation.
       </p>
@@ -304,7 +304,7 @@
           Screen orientation types and locks
         </h2>
         <p>
-          <dfn>landscape-primary</dfn> is an orientation where the screen width
+          <dfn>Landscape-primary</dfn> is an orientation where the screen width
           is greater than the screen height. If the device's natural
           orientation is landscape, then it is in landscape-primary when held
           in that position. If the device's natural orientation is portrait,
@@ -312,16 +312,16 @@
           shown <a>screen orientation values table</a>.
         </p>
         <p>
-          <dfn>landscape-secondary</dfn> is an orientation where the screen
+          <dfn>Landscape-secondary</dfn> is an orientation where the screen
           width is greater than the screen height. If the device's natural
           orientation is landscape, it is in landscape-secondary when rotated
-          180º from it's natural orientation. If the device's natural
+          180º from its natural orientation. If the device's natural
           orientation is portrait, the <a>user agent</a> sets
           landscape-secondary from the two options as shown in the <a>screen
           orientation values table</a>.
         </p>
         <p>
-          <dfn>portrait-primary</dfn> is an orientation where the screen width
+          <dfn>Portrait-primary</dfn> is an orientation where the screen width
           is less than or equal to the screen height. If the device's natural
           orientation is portrait, then it is in portrait-primary when held in
           that position. If the device's natural orientation is landscape, the
@@ -329,7 +329,7 @@
           in the <a>screen orientation values table</a>.
         </p>
         <p>
-          <dfn>portrait-secondary</dfn> is an orientation where the screen
+          <dfn>Portrait-secondary</dfn> is an orientation where the screen
           width is less than or equal to the screen height. If the device's
           natural orientation is portrait, then it is in portrait-secondary
           when rotated 180º from it's natural position. If the device's natural
@@ -795,7 +795,7 @@ async function rotate() {
           </li>
         </ol>
       </section>
-      <section data-dfn-for="OrientationLockType" data-link-for=
+      <section data-link-for=
       "OrientationType">
         <h2>
           <dfn>Locking orientation algorithm</dfn>

--- a/index.html
+++ b/index.html
@@ -183,13 +183,13 @@
         </pre>
       <p data-dfn-for="OrientationLockType">
         The <dfn>OrientationLockType</dfn> enum represents the screen
-        orientations to which a screen can be locked: the "<dfn>any</dfn>" enum value
-        represents the <a>any</a> orientation, the "<dfn>natural</dfn>" enum
-        represents the <a>natural</a> orientation, the "<dfn>landscape</dfn>"
-        enum represents the <a>landscape</a> orientation, the
-        "<dfn>portrait</dfn>" enum represents the <a>portrait</a> orientation,
-        the "<dfn>portrait-primary</dfn>" enum represents the
-        <a>portrait-primary</a> orientation, the
+        orientations to which a screen can be locked: the "<dfn>any</dfn>" enum
+        value represents the <a>any</a> orientation, the "<dfn>natural</dfn>"
+        enum represents the <a>natural</a> orientation, the
+        "<dfn>landscape</dfn>" enum represents the <a>landscape</a>
+        orientation, the "<dfn>portrait</dfn>" enum represents the
+        <a>portrait</a> orientation, the "<dfn>portrait-primary</dfn>" enum
+        represents the <a>portrait-primary</a> orientation, the
         "<dfn>portrait-secondary</dfn>" enum represents the
         <a>portrait-secondary</a> orientation, the
         "<dfn>landscape-primary</dfn>" enum represents the
@@ -200,8 +200,7 @@
       <p data-dfn-for="OrientationType">
         The <dfn>OrientationType</dfn> enum represents the actual current
         screen orientation that the screen is in irrespective of which lock is
-        applied: the
-        "<dfn>portrait-primary</dfn>" enum represents the
+        applied: the "<dfn>portrait-primary</dfn>" enum represents the
         <a>portrait-primary</a> orientation, the
         "<dfn>portrait-secondary</dfn>" enum represents the
         <a>portrait-secondary</a> orientation, the

--- a/index.html
+++ b/index.html
@@ -183,24 +183,33 @@
         </pre>
       <p data-dfn-for="OrientationLockType">
         The <dfn>OrientationLockType</dfn> enum represents the screen
-        orientations to which a screen can be locked. The screen can be locked to the following enum values: 
-        the "<dfn>any</dfn>" enum value represents the <a>any</a> orientation, 
-        the "<dfn>natural</dfn>" enum represents the <a>natural</a> orientation, 
-        the "<dfn>landscape</dfn>" enum represents the <a>landscape</a> orientation,
-        the "<dfn>portrait</dfn>" enum represents the <a>portrait</a> orientation,
-        the "<dfn>portrait-primary</dfn>" enum represents the <a>portrait-primary</a> orientation,
-        the "<dfn>portrait-secondary</dfn>" enum represents the <a>portrait-secondary</a> orientation,
-        the "<dfn>landscape-primary</dfn>" enum represents the <a>landscape-primary</a> orientation,
-        the "<dfn>landscape-secondary</dfn>" enum represents the <a>landscape-secondary</a> orientation.
+        orientations to which a screen can be locked. The screen can be locked
+        to the following enum values: the "<dfn>any</dfn>" enum value
+        represents the <a>any</a> orientation, the "<dfn>natural</dfn>" enum
+        represents the <a>natural</a> orientation, the "<dfn>landscape</dfn>"
+        enum represents the <a>landscape</a> orientation, the
+        "<dfn>portrait</dfn>" enum represents the <a>portrait</a> orientation,
+        the "<dfn>portrait-primary</dfn>" enum represents the
+        <a>portrait-primary</a> orientation, the
+        "<dfn>portrait-secondary</dfn>" enum represents the
+        <a>portrait-secondary</a> orientation, the
+        "<dfn>landscape-primary</dfn>" enum represents the
+        <a>landscape-primary</a> orientation, the
+        "<dfn>landscape-secondary</dfn>" enum represents the
+        <a>landscape-secondary</a> orientation.
       </p>
       <p data-dfn-for="OrientationType">
-        The <dfn>OrientationType</dfn> enum represents the actual
-        current screen orientation that the screen is in irrespective of which
-        lock is applied. The current screen orientation can be:
-        the "<dfn>portrait-primary</dfn>" enum represents the <a>portrait-primary</a> orientation,
-        the "<dfn>portrait-secondary</dfn>" enum represents the <a>portrait-secondary</a> orientation,
-        the "<dfn>landscape-primary</dfn>" enum represents the <a>landscape-primary</a> orientation,
-        the "<dfn>landscape-secondary</dfn>" enum represents the <a>landscape-secondary</a> orientation.
+        The <dfn>OrientationType</dfn> enum represents the actual current
+        screen orientation that the screen is in irrespective of which lock is
+        applied. The current screen orientation can be: the
+        "<dfn>portrait-primary</dfn>" enum represents the
+        <a>portrait-primary</a> orientation, the
+        "<dfn>portrait-secondary</dfn>" enum represents the
+        <a>portrait-secondary</a> orientation, the
+        "<dfn>landscape-primary</dfn>" enum represents the
+        <a>landscape-primary</a> orientation, the
+        "<dfn>landscape-secondary</dfn>" enum represents the
+        <a>landscape-secondary</a> orientation.
       </p>
       <section>
         <h2>
@@ -252,9 +261,9 @@
         <div class='note'>
           <p>
             <a>angle</a> indicates how far the user has turned the device
-            counterclockwise from the <a>natural</a> orientation. When the device is
-            rotated 90° counterclockwise, the screen compensates by rotating
-            90° clockwise, so <a>angle</a> returns <code>90</code>.
+            counterclockwise from the <a>natural</a> orientation. When the
+            device is rotated 90° counterclockwise, the screen compensates by
+            rotating 90° clockwise, so <a>angle</a> returns <code>90</code>.
           </p>
           <p>
             If the device is rotated 90° clockwise from its <a>natural</a>
@@ -296,38 +305,61 @@
         <h2>
           Screen orientation types and locks
         </h2>
-        <p><dfn>landscape-primary</dfn> is an orientation where the screen width is greater than the screen height.  If the device's natural orientation is landscape, 
-          then it is in landscape-primary when held in that position.  If the device's natural orientation is portrait, the <a>user agent</a> sets landscape-primary 
-          from the two options as shown <a>screen orientation values table</a>.
+        <p>
+          <dfn>landscape-primary</dfn> is an orientation where the screen width
+          is greater than the screen height. If the device's natural
+          orientation is landscape, then it is in landscape-primary when held
+          in that position. If the device's natural orientation is portrait,
+          the <a>user agent</a> sets landscape-primary from the two options as
+          shown <a>screen orientation values table</a>.
         </p>
         <p>
-          <dfn>landscape-secondary</dfn> is an orientation where the screen width is greater than the screen height.  If the device's natural orientation is landscape, it is in landscape-secondary 
-          when rotated 180º from it's natural orientation.  If the device's natural orientation is portrait, the <a>user agent</a> sets landscape-secondary 
-          from the two options as shown in the <a>screen orientation values table</a>.
+          <dfn>landscape-secondary</dfn> is an orientation where the screen
+          width is greater than the screen height. If the device's natural
+          orientation is landscape, it is in landscape-secondary when rotated
+          180º from it's natural orientation. If the device's natural
+          orientation is portrait, the <a>user agent</a> sets
+          landscape-secondary from the two options as shown in the <a>screen
+          orientation values table</a>.
         </p>
         <p>
-          <dfn>portrait-primary</dfn> is an orientation where the screen width is less than or equal to the screen height.  If the device's natural orientation is portrait, then it 
-          is in portrait-primary when held in that position.  If the device's natural orientation is landscape, the <a>user agent</a> sets portrait-primary from the two options as shown in the 
-          <a>screen orientation values table</a>.
+          <dfn>portrait-primary</dfn> is an orientation where the screen width
+          is less than or equal to the screen height. If the device's natural
+          orientation is portrait, then it is in portrait-primary when held in
+          that position. If the device's natural orientation is landscape, the
+          <a>user agent</a> sets portrait-primary from the two options as shown
+          in the <a>screen orientation values table</a>.
         </p>
         <p>
-          <dfn>portrait-secondary</dfn> is an orientation where the screen width is less than or equal to the screen height.  If the device's natural orientation is portrait, then it 
-          is in portrait-secondary when rotated 180º from it's natural position.  If the device's natural orientation is landscape, the <a>user agent</a> sets portrait-secondary 
-          from the two options as shown in the <a>screen orientation values table</a>.
+          <dfn>portrait-secondary</dfn> is an orientation where the screen
+          width is less than or equal to the screen height. If the device's
+          natural orientation is portrait, then it is in portrait-secondary
+          when rotated 180º from it's natural position. If the device's natural
+          orientation is landscape, the <a>user agent</a> sets
+          portrait-secondary from the two options as shown in the <a>screen
+          orientation values table</a>.
         </p>
         <p>
-          <dfn>portrait</dfn> is an orientation where the screen width is less than or equal to the screen height and depending on platform convention locking the screen to
-          portrait can represent portrait-primary, portrait-secondary or both.
+          <dfn>portrait</dfn> is an orientation where the screen width is less
+          than or equal to the screen height and depending on platform
+          convention locking the screen to portrait can represent
+          portrait-primary, portrait-secondary or both.
         </p>
         <p>
-          <dfn>landscape</dfn> is an orientation where the screen width is greater than the screen height and depending on platform convention locking the screen to landscape can 
-          represent landscape-primary, landscape-secondary or both.
+          <dfn>landscape</dfn> is an orientation where the screen width is
+          greater than the screen height and depending on platform convention
+          locking the screen to landscape can represent landscape-primary,
+          landscape-secondary or both.
         </p>
         <p>
-          <dfn>natural</dfn> is an orientation that refers to either portrait-primary or landscape-primary depending on the device's usual orientation.
+          <dfn>natural</dfn> is an orientation that refers to either
+          portrait-primary or landscape-primary depending on the device's usual
+          orientation.
         </p>
         <p>
-          <dfn>any</dfn> is an orientation that means the screen can be locked to any one of portrait-primary, portrait-secondary, landscape-primary and landscape-secondary.
+          <dfn>any</dfn> is an orientation that means the screen can be locked
+          to any one of portrait-primary, portrait-secondary, landscape-primary
+          and landscape-secondary.
         </p>
       </section>
       <section data-dfn-for='OrientationType' data-link-for="OrientationType">
@@ -349,13 +381,13 @@
           that for any given type, there will be a specific angle associated.
         </p>
         <p>
-          One primary orientation will always be determined by the <a>natural</a>
-          orientation of the device and this will then determine the secondary
-          value of its related orientation.
+          One primary orientation will always be determined by the
+          <a>natural</a> orientation of the device and this will then determine
+          the secondary value of its related orientation.
         </p>
         <p>
-          For example a device held in its natural <a>portrait</a> orientation would
-          have a current orientation of <a>portrait-primary</a> and its
+          For example a device held in its natural <a>portrait</a> orientation
+          would have a current orientation of <a>portrait-primary</a> and its
           <a>portrait-secondary</a> orientation would be its position when
           rotated 180°.
         </p>
@@ -370,9 +402,9 @@
           orientation types: <a>portrait-primary</a>,
           <a>portrait-secondary</a>, <a>landscape-primary</a> and
           <a>landscape-secondary</a>. The table shows the primary and secondary
-          values that are determined by the device's <a>natural</a> orientation and
-          the possibilities available to the <a>user agent</a> for setting the
-          other primary and secondary orientation values.
+          values that are determined by the device's <a>natural</a> orientation
+          and the possibilities available to the <a>user agent</a> for setting
+          the other primary and secondary orientation values.
         </p>
         <table>
           <caption>
@@ -464,8 +496,9 @@
             would be wrong given that a device might have <code>90</code> and
             <code>270</code> as the angles for <code>landscape</code> types but
             another device will have <code>0</code> and <code>180</code>,
-            depending on its <a>natural</a> orientation. Instead, it is recommended to
-            check during runtime the relationship between angle and type.
+            depending on its <a>natural</a> orientation. Instead, it is
+            recommended to check during runtime the relationship between angle
+            and type.
           </p>
         </div>
       </section>
@@ -757,8 +790,8 @@ async function rotate() {
           </li>
           <li>Set the <a>document</a>'s <a>current orientation angle</a> to the
           clockwise angle in degrees between the orientation of the viewport as
-          it is drawn and the <a>natural</a>orientation of the device (i.e., the top
-          of the physical screen). This is the opposite of the physical
+          it is drawn and the <a>natural</a>orientation of the device (i.e.,
+          the top of the physical screen). This is the opposite of the physical
           rotation. In other words, if a device is turned 90 degrees on the
           right, the <a>current orientation angle</a> would be 270 degrees.
           </li>

--- a/index.html
+++ b/index.html
@@ -140,9 +140,11 @@
         </h2>
         <p>
           The <a data-link-for="Screen">orientation</a> attribute is an
-          instance of <a>ScreenOrientation</a>.  This attribute provides the current orientation, 
-          current angle and whether there was an onchange event.  The <a>user agent</a> MUST run the 
-          <a>updating orientation algorithm</a> steps to initialize the values and return the <a data-link-for="Screen">orientation</a> attribute.
+          instance of <a>ScreenOrientation</a>. This attribute provides the
+          current orientation, current angle and whether there was an onchange
+          event. The <a>user agent</a> MUST run the <a>updating orientation
+          algorithm</a> steps to initialize the values and return the
+          <a data-link-for="Screen">orientation</a> attribute.
         </p>
       </section>
     </section>
@@ -161,11 +163,11 @@
             attribute EventHandler onchange;
           };
         </pre>
-          <section>
-              <h2>
-                <dfn>OrientationType</dfn> enum
-              </h2>
-              <pre class='idl'>
+      <section>
+        <h2>
+          <dfn>OrientationType</dfn> enum
+        </h2>
+        <pre class='idl'>
                   enum OrientationType {
                     "portrait-primary",
                     "portrait-secondary",
@@ -173,13 +175,13 @@
                     "landscape-secondary"
                   };
                 </pre>
-            </section>
-            <section data-link-for="OrientationLockType" data-dfn-for=
-            "OrientationLockType">
-              <h2>
-                <dfn>OrientationLockType</dfn> enum
-              </h2>
-              <pre class='idl'>
+      </section>
+      <section data-link-for="OrientationLockType" data-dfn-for=
+      "OrientationLockType">
+        <h2>
+          <dfn>OrientationLockType</dfn> enum
+        </h2>
+        <pre class='idl'>
                   enum OrientationLockType {
                     "any",
                     "natural",
@@ -191,7 +193,7 @@
                     "landscape-secondary"
                   };
                 </pre>
-            </section>            
+      </section>
       <section>
         <h2>
           <dfn>lock()</dfn> method
@@ -332,7 +334,8 @@
           <thead>
             <tr>
               <th>
-                  <dfn data-dfn-for="OrientationLockType">Natural</dfn> Orientation
+                <dfn data-dfn-for="OrientationLockType">Natural</dfn>
+                Orientation
               </th>
               <th>
                 Primary Orientation 1
@@ -374,7 +377,7 @@
             </tr>
             <tr>
               <td>
-                  <dfn data-dfn-for="OrientationLockType">Landscape</dfn>
+                <dfn data-dfn-for="OrientationLockType">Landscape</dfn>
               </td>
               <td>
                 <a>landscape-primary</a><br>
@@ -702,8 +705,7 @@ async function rotate() {
           </li>
           <li>Otherwise, if the screen width is less than or equal to the
           screen height, set the <a>document</a>'s <a>current orientation
-          type</a> to <a>portrait-primary</a> or
-          <a>portrait-secondary</a>.
+          type</a> to <a>portrait-primary</a> or <a>portrait-secondary</a>.
           </li>
           <li>Set the <a>document</a>'s <a>current orientation angle</a> to the
           clockwise angle in degrees between the orientation of the viewport as
@@ -714,7 +716,8 @@ async function rotate() {
           </li>
         </ol>
       </section>
-      <section data-dfn-for="OrientationLockType" data-link-for="OrientationType">
+      <section data-dfn-for="OrientationLockType" data-link-for=
+      "OrientationType">
         <h2>
           <dfn>Locking orientation algorithm</dfn>
         </h2>
@@ -766,9 +769,10 @@ async function rotate() {
           </li>
           <li>Depending on <var>orientation</var> value, do the following:
             <dl>
+              <dd>
                 <a>portrait-primary</a> or <a>portrait-secondary</a> or
                 <a>landscape-primary</a> or <a>landscape-secondary</a>
-              </dt>
+              </dd>
               <dd>
                 Append <var>orientation</var> to <var>orientations</var>.
               </dd>
@@ -1090,8 +1094,8 @@ async function rotate() {
       </p>
       <p>
         The following is defined in [[DOM]]: <dfn data-cite=
-        "DOM#concept-event-fire">fire an event</dfn>,
-        <dfn data-cite="DOM#interface-eventtarget">EventTarget</dfn>
+        "DOM#concept-event-fire">fire an event</dfn>, <dfn data-cite=
+        "DOM#interface-eventtarget">EventTarget</dfn>
       </p>
       <p>
         The following is used but not defined in [[FULLSCREEN]]: <dfn><a href=

--- a/index.html
+++ b/index.html
@@ -795,8 +795,7 @@ async function rotate() {
           </li>
         </ol>
       </section>
-      <section data-link-for=
-      "OrientationType">
+      <section data-link-for="OrientationType">
         <h2>
           <dfn>Locking orientation algorithm</dfn>
         </h2>

--- a/index.html
+++ b/index.html
@@ -121,7 +121,7 @@
     </section>
     <section data-dfn-for='Screen'>
       <h2>
-        Extensions to the <a>Screen</a> interface
+        Extensions to the <code>Screen</code> interface
       </h2>
       <p>
         The <a data-cite="CSSOM-View">CSSOM View Module</a> specification
@@ -140,7 +140,9 @@
         </h2>
         <p>
           The <a data-link-for="Screen">orientation</a> attribute is an
-          instance of <a>ScreenOrientation</a>.
+          instance of <a>ScreenOrientation</a>.  This attribute provides the current orientation, 
+          current angle and whether there was an onchange event.  The <a>user agent</a> MUST run the 
+          <a>updating orientation algorithm</a> steps to initialize the values and return the <a data-link-for="Screen">orientation</a> attribute.
         </p>
       </section>
     </section>
@@ -159,6 +161,37 @@
             attribute EventHandler onchange;
           };
         </pre>
+          <section>
+              <h2>
+                <dfn>OrientationType</dfn> enum
+              </h2>
+              <pre class='idl'>
+                  enum OrientationType {
+                    "portrait-primary",
+                    "portrait-secondary",
+                    "landscape-primary",
+                    "landscape-secondary"
+                  };
+                </pre>
+            </section>
+            <section data-link-for="OrientationLockType" data-dfn-for=
+            "OrientationLockType">
+              <h2>
+                <dfn>OrientationLockType</dfn> enum
+              </h2>
+              <pre class='idl'>
+                  enum OrientationLockType {
+                    "any",
+                    "natural",
+                    "landscape",
+                    "portrait",
+                    "portrait-primary",
+                    "portrait-secondary",
+                    "landscape-primary",
+                    "landscape-secondary"
+                  };
+                </pre>
+            </section>            
       <section>
         <h2>
           <dfn>lock()</dfn> method
@@ -236,37 +269,6 @@
     </section>
     <section>
       <h2>
-        <dfn>OrientationType</dfn> enum
-      </h2>
-      <pre class='idl'>
-          enum OrientationType {
-            "portrait-primary",
-            "portrait-secondary",
-            "landscape-primary",
-            "landscape-secondary"
-          };
-        </pre>
-    </section>
-    <section data-link-for="OrientationLockType" data-dfn-for=
-    "OrientationLockType">
-      <h2>
-        <dfn>OrientationLockType</dfn> enum
-      </h2>
-      <pre class='idl'>
-          enum OrientationLockType {
-            "any",
-            "natural",
-            "landscape",
-            "portrait",
-            "portrait-primary",
-            "portrait-secondary",
-            "landscape-primary",
-            "landscape-secondary"
-          };
-        </pre>
-    </section>
-    <section>
-      <h2>
         Concepts
       </h2>
       <p>
@@ -326,11 +328,11 @@
             The <dfn>screen orientation values table</dfn>
           </caption>
         </table>
-        <table data-link-for="OrientationType">
+        <table data-dfn-for="OrientationType">
           <thead>
             <tr>
               <th>
-                Natural Orientation
+                  <dfn data-dfn-for="OrientationLockType">Natural</dfn> Orientation
               </th>
               <th>
                 Primary Orientation 1
@@ -349,30 +351,30 @@
           <tbody>
             <tr>
               <td>
-                Portrait
+                <dfn data-dfn-for="OrientationLockType">Portrait</dfn>
               </td>
               <td>
-                <a>portrait-primary</a><br>
+                <dfn>portrait-primary</dfn><br>
                 <a data-link-for="ScreenOrientation">Angle</a> <code>0</code>
               </td>
               <td>
-                <a>portrait-secondary</a><br>
+                <dfn>portrait-secondary</dfn><br>
                 <a data-link-for="ScreenOrientation">Angle</a> <code>180</code>
               </td>
               <td>
-                <a>landscape-primary</a><br>
+                <dfn>landscape-primary</dfn><br>
                 <a>User agent</a> to set at either <a data-link-for=
                 "ScreenOrientation">Angle</a> <code>90</code> or
                 <a data-link-for="ScreenOrientation">Angle</a> <code>270</code>
               </td>
               <td>
-                <a>landscape-secondary</a><br>
+                <dfn>landscape-secondary</dfn><br>
                 Set at the angle not used for landscape-primary
               </td>
             </tr>
             <tr>
               <td>
-                Landscape
+                  <dfn data-dfn-for="OrientationLockType">Landscape</dfn>
               </td>
               <td>
                 <a>landscape-primary</a><br>
@@ -685,7 +687,7 @@ async function rotate() {
       <h2>
         Algorithms
       </h2>
-      <section data-dfn-for="OrientationType">
+      <section data-link-for="OrientationType">
         <h2>
           <dfn>Updating orientation algorithm</dfn>
         </h2>
@@ -696,12 +698,12 @@ async function rotate() {
         <ol>
           <li>If the screen width is greater than the screen height, set the
           <a>document</a>'s <a>current orientation type</a> to
-          <dfn>landscape-primary</dfn> or <dfn>landscape-secondary</dfn>.
+          <a>landscape-primary</a> or <a>landscape-secondary</a>.
           </li>
           <li>Otherwise, if the screen width is less than or equal to the
           screen height, set the <a>document</a>'s <a>current orientation
-          type</a> to <dfn>portrait-primary</dfn> or
-          <dfn>portrait-secondary</dfn>.
+          type</a> to <a>portrait-primary</a> or
+          <a>portrait-secondary</a>.
           </li>
           <li>Set the <a>document</a>'s <a>current orientation angle</a> to the
           clockwise angle in degrees between the orientation of the viewport as
@@ -712,7 +714,7 @@ async function rotate() {
           </li>
         </ol>
       </section>
-      <section data-dfn-for="OrientationLockType">
+      <section data-dfn-for="OrientationLockType" data-link-for="OrientationType">
         <h2>
           <dfn>Locking orientation algorithm</dfn>
         </h2>
@@ -764,15 +766,14 @@ async function rotate() {
           </li>
           <li>Depending on <var>orientation</var> value, do the following:
             <dl>
-              <dt>
-                <dfn>portrait-primary</dfn> or <dfn>portrait-secondary</dfn> or
-                <dfn>landscape-primary</dfn> or <dfn>landscape-secondary</dfn>
+                <a>portrait-primary</a> or <a>portrait-secondary</a> or
+                <a>landscape-primary</a> or <a>landscape-secondary</a>
               </dt>
               <dd>
                 Append <var>orientation</var> to <var>orientations</var>.
               </dd>
               <dt>
-                <dfn data-dfn-for='OrientationLockType'>landscape</dfn>
+                <a data-link-for='OrientationLockType'>landscape</a>
               </dt>
               <dd>
                 Depending on platform convention, append
@@ -781,7 +782,7 @@ async function rotate() {
                 <var>orientations</var>.
               </dd>
               <dt>
-                <dfn data-dfn-for='OrientationLockType'>portrait</dfn>
+                <a data-link-for='OrientationLockType'>portrait</a>
               </dt>
               <dd>
                 Depending on platform convention, append
@@ -790,7 +791,7 @@ async function rotate() {
                 <var>orientations</var>.
               </dd>
               <dt>
-                <dfn data-dfn-for='OrientationLockType'>natural</dfn>
+                <a data-link-for='OrientationLockType'>natural</a>
               </dt>
               <dd>
                 Append <code>portrait-primary</code> or
@@ -1089,7 +1090,8 @@ async function rotate() {
       </p>
       <p>
         The following is defined in [[DOM]]: <dfn data-cite=
-        "DOM#concept-event-fire">fire an event</dfn>.
+        "DOM#concept-event-fire">fire an event</dfn>,
+        <dfn data-cite="DOM#interface-eventtarget">EventTarget</dfn>
       </p>
       <p>
         The following is used but not defined in [[FULLSCREEN]]: <dfn><a href=


### PR DESCRIPTION
2.1 - Added further explanation to 2.1
3. - Linked EventTarget to DOM
3.1  - Moved up OrientationType enum and changed all definitions to the table
3.2 - Moved up OrientationLockType enum and changed the portrait, landscape and natural definitions to the table.  I am not sure what to do the with portrait-primary, portrait-secondary, landscape-primary and landscape-secondary - the ones that are the same as OrientationType enum.  Do they point to the same definitions in the table as OrientationType definitions?  Wasn't sure how to do assign two definitions to one element


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Johanna-hub/screen-orientation/pull/139.html" title="Last updated on Jan 31, 2019, 12:23 PM UTC (ab44f35)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-orientation/139/0e1dca5...Johanna-hub:ab44f35.html" title="Last updated on Jan 31, 2019, 12:23 PM UTC (ab44f35)">Diff</a>