### PR TITLE
Resolving the promise after the change event is fired

### DIFF
--- a/index.html
+++ b/index.html
@@ -1005,15 +1005,6 @@
               <li>
                 <a>Update the orientation information</a> of <var>doc</var>.
               </li>
-              <li>If <var>doc</var>'s <a>pending promise</a> is not
-              <code>null</code>:
-                <ol>
-                  <li>Resolve <var>doc</var>'s <a>pending promise</a> with
-                  <code>undefined</code>.
-                  </li>
-                  <li>Set <var>doc</var>'s <a>pending promise</a> to
-                  <code>null</code> .
-                  </li>
                 </ol>
               </li>
               <li>If the orientation change was triggered by a user gesture
@@ -1026,6 +1017,15 @@
                 <a>Fire an event</a> named <code>change</code> at
                 <var>doc</var>'s <a>screen.orientation</a> object.
               </li>
+              <li>If <var>doc</var>'s <a>pending promise</a> is not
+                <code>null</code>:
+                  <ol>
+                    <li>Resolve <var>doc</var>'s <a>pending promise</a> with
+                    <code>undefined</code>.
+                    </li>
+                    <li>Set <var>doc</var>'s <a>pending promise</a> to
+                    <code>null</code> .
+                    </li>
             </ol>
           </li>
         </ol>
@@ -1048,6 +1048,16 @@
           <a>document</a>'s <a>current orientation angle</a>, run the following
           sub-steps:
             <ol>
+              <li>If the orientation change was triggered by a user gesture
+              such as the user turning the device, as opposed to a call to <a>
+                lock()</a>, the <a>task</a> MUST be annotated with
+                <code>process user orientation change</code> when running the
+                next step.
+              </li>
+              <li>
+                <a>Fire an event</a> named <code>change</code> at the
+                <a>document</a>'s <a>screen.orientation</a> object.
+              </li>
               <li>If the <a>document</a>'s <a>pending promise</a> is not <code>
                 null</code>:
                 <ol>
@@ -1058,16 +1068,6 @@
                   <code>null</code>.
                   </li>
                 </ol>
-              </li>
-              <li>If the orientation change was triggered by a user gesture
-              such as the user turning the device, as opposed to a call to <a>
-                lock()</a>, the <a>task</a> MUST be annotated with
-                <code>process user orientation change</code> when running the
-                next step.
-              </li>
-              <li>
-                <a>Fire an event</a> named <code>change</code> at the
-                <a>document</a>'s <a>screen.orientation</a> object.
               </li>
             </ol>
           </li>

--- a/index.html
+++ b/index.html
@@ -150,12 +150,12 @@
     console.log(`Orientation type is ${type} & angle is ${angle}.`);
   }
   
-  screen.orientation.addEventListener("change", () => {
+  screen.orientation.addEventListener("change", () =&gt; {
     show();
     updateDetails(document.getElementById("button"));
   });
   
-  window.addEventListener("load", () => {
+  window.addEventListener("load", () =&gt; {
     show();
     updateDetails(document.getElementById("button"));
   });
@@ -1005,27 +1005,26 @@
               <li>
                 <a>Update the orientation information</a> of <var>doc</var>.
               </li>
-                </ol>
+            </ol>
+          </li>
+          <li>If the orientation change was triggered by a user gesture such as
+          the user turning the device, as opposed to a call to <a>lock()</a>,
+          the <a>task</a> MUST be annotated with <code>process user orientation
+          change</code> when running the next step.
+          </li>
+          <li>
+            <a>Fire an event</a> named <code>change</code> at <var>doc</var>'s
+            <a>screen.orientation</a> object.
+          </li>
+          <li>If <var>doc</var>'s <a>pending promise</a> is not
+          <code>null</code>:
+            <ol>
+              <li>Resolve <var>doc</var>'s <a>pending promise</a> with
+              <code>undefined</code>.
               </li>
-              <li>If the orientation change was triggered by a user gesture
-              such as the user turning the device, as opposed to a call to <a>
-                lock()</a>, the <a>task</a> MUST be annotated with
-                <code>process user orientation change</code> when running the
-                next step.
+              <li>Set <var>doc</var>'s <a>pending promise</a> to
+              <code>null</code> .
               </li>
-              <li>
-                <a>Fire an event</a> named <code>change</code> at
-                <var>doc</var>'s <a>screen.orientation</a> object.
-              </li>
-              <li>If <var>doc</var>'s <a>pending promise</a> is not
-                <code>null</code>:
-                  <ol>
-                    <li>Resolve <var>doc</var>'s <a>pending promise</a> with
-                    <code>undefined</code>.
-                    </li>
-                    <li>Set <var>doc</var>'s <a>pending promise</a> to
-                    <code>null</code> .
-                    </li>
             </ol>
           </li>
         </ol>


### PR DESCRIPTION
Closes #120

The following tasks have been completed:

 * [x] Confirmed there are no ReSpec/BikeShed errors or warnings.
 * [x] Modified Web platform tests https://github.com/web-platform-tests/wpt/pull/15267

Implementation commitment:

 * [ ] WebKit 
 * [x] [Chromium](https://bugs.chromium.org/p/chromium/issues/detail?id=930237)
 * [x] [Gecko](https://bugzilla.mozilla.org/show_bug.cgi?id=1525582)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Johanna-hub/screen-orientation/pull/147.html" title="Last updated on Feb 19, 2019, 10:38 AM UTC (19e5f68)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-orientation/147/e41f97e...Johanna-hub:19e5f68.html" title="Last updated on Feb 19, 2019, 10:38 AM UTC (19e5f68)">Diff</a>