### PR TITLE
Add test link for lock-bad-argument

### DIFF
--- a/index.html
+++ b/index.html
@@ -331,7 +331,7 @@
         <h2>
           <dfn>lock()</dfn> method: Lock screen to a specific orientation
         </h2>
-        <p>
+        <p data-tests="lock-bad-argument.html">
           When the <a>lock()</a> method is invoked, the <a>user agent</a> MUST
           run the <a>apply an orientation lock</a> steps to the <a>responsible
           document</a> using <var>orientation</var>.


### PR DESCRIPTION
Adds a link to the` lock()method` definition for `lock-bad-argument.html`


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Johanna-hub/screen-orientation/pull/152.html" title="Last updated on Feb 13, 2019, 7:54 PM UTC (8f63b74)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-orientation/152/1864271...Johanna-hub:8f63b74.html" title="Last updated on Feb 13, 2019, 7:54 PM UTC (8f63b74)">Diff</a>