### PR TITLE
Add test link for lock-basic.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -839,7 +839,7 @@
         <h2>
           <dfn>Locking orientation algorithm</dfn>
         </h2>
-        <p>
+        <p data-tests="lock-basic.html">
           The steps to <dfn>apply an orientation lock</dfn> to a
           <a>document</a> using <var>orientation</var> are as follows:
         </p>

--- a/index.html
+++ b/index.html
@@ -331,7 +331,7 @@
         <h2>
           <dfn>lock()</dfn> method: Lock screen to a specific orientation
         </h2>
-        <p>
+        <p data-tests="lock-basic.html">
           When the <a>lock()</a> method is invoked, the <a>user agent</a> MUST
           run the <a>apply an orientation lock</a> steps to the <a>responsible
           document</a> using <var>orientation</var>.
@@ -839,7 +839,7 @@
         <h2>
           <dfn>Locking orientation algorithm</dfn>
         </h2>
-        <p data-tests="lock-basic.html">
+        <p>
           The steps to <dfn>apply an orientation lock</dfn> to a
           <a>document</a> using <var>orientation</var> are as follows:
         </p>


### PR DESCRIPTION
Adds the tests from lock-basic.html to the `Locking orientation algorithm`


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Johanna-hub/screen-orientation/pull/153.html" title="Last updated on Feb 19, 2019, 12:52 AM UTC (fc5b7bc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-orientation/153/94dae87...Johanna-hub:fc5b7bc.html" title="Last updated on Feb 19, 2019, 12:52 AM UTC (fc5b7bc)">Diff</a>