### PR TITLE
Add lock-sandboxed-iframe test 

### DIFF
--- a/index.html
+++ b/index.html
@@ -877,12 +877,12 @@
               </li>
             </ol>
           </li>
-          <li>If the <a>document</a>'s <a>active sandboxing flag set</a> has
-          the <a>sandboxed orientation lock browsing context flag</a> set, or
-          <a>user agent</a> doesn't meet the <a>pre-lock conditions</a> to
-          perform an orientation change, return a promise rejected with a
-          <code>DOMException</code> whose name is <code>SecurityError</code>
-          and abort these steps.
+          <li data-tests="lock-sandboxed-iframe.html">If the <a>document</a>'s
+          <a>active sandboxing flag set</a> has the <a>sandboxed orientation
+          lock browsing context flag</a> set, or <a>user agent</a> doesn't meet
+          the <a>pre-lock conditions</a> to perform an orientation change,
+          return a promise rejected with a <code>DOMException</code> whose name
+          is <code>SecurityError</code> and abort these steps.
           </li>
           <li>Let <var>orientations</var> be an empty list.
           </li>


### PR DESCRIPTION
Add lock-sandboxed-iframe test to specific step in the locking algorithm section


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Johanna-hub/screen-orientation/pull/156.html" title="Last updated on Feb 14, 2019, 4:05 PM UTC (f3e324f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-orientation/156/1864271...Johanna-hub:f3e324f.html" title="Last updated on Feb 14, 2019, 4:05 PM UTC (f3e324f)">Diff</a>