### PR TITLE
Edit screen orientation type definitions

### DIFF
--- a/index.html
+++ b/index.html
@@ -526,13 +526,21 @@
         <p>
           <dfn>Natural</dfn> is an orientation that refers to either
           portrait-primary or landscape-primary depending on the device's usual
-          orientation.
+          orientation. This orientation is determined by the device's operating
+          system.
         </p>
         <p>
           <dfn>Any</dfn> is an orientation that means the screen can be locked
           to any one of portrait-primary, portrait-secondary, landscape-primary
           and landscape-secondary.
         </p>
+        <p>
+          The <dfn>default orientation</dfn> is the set of orientations to
+          which the screen is locked when there is no current <a>orientation
+          lock</a>. This orientation is determined by the device's operating
+          system.
+        </p>
+        <div class="issue" data-number="150"></div>
       </section>
       <section data-dfn-for='OrientationType' data-link-for="OrientationType">
         <h2>
@@ -707,23 +715,18 @@
           An <dfn>orientation lock</dfn> is in place when the screen has
           successfully been locked to a specific orientation.
         </p>
-      </section>
-      <section>
-        <h2>
-          Default orientation
-        </h2>
-        <p>
-          The <dfn>default orientation</dfn> is the set of orientations to
-          which the screen is locked when there is no current <a>orientation
-          lock</a>.
-        </p>
-        <div class="issue" data-number="150"></div>
-        <p>
-          From the perspective of a <a>document</a>, locking to the <a>default
-          orientation</a> is equivalent to unlocking because it means that it
-          no longer has a lock applied. However, this does not mean that the
-          <a>[[\defaultOrientation]]</a> only contains the item <a>any</a>.
-        </p>
+        <section>
+          <h2>
+            Locking to the default orientation
+          </h2>
+          <p>
+            From the perspective of a <a>document</a>, locking to the
+            <a>default orientation</a> is equivalent to unlocking because it
+            means that it no longer has a lock applied. However, this does not
+            mean that the <a>[[\defaultOrientation]]</a> only contains the item
+            <a>any</a>.
+          </p>
+        </section>
       </section>
     </section>
     <section>

--- a/index.html
+++ b/index.html
@@ -526,8 +526,8 @@
         <p>
           <dfn>Natural</dfn> is an orientation that refers to either
           portrait-primary or landscape-primary depending on the device's usual
-          orientation. This orientation is determined by the device's operating
-          system.
+          orientation. This orientation is usually provided by the underlying
+          operating system.
         </p>
         <p>
           <dfn>Any</dfn> is an orientation that means the screen can be locked
@@ -538,7 +538,7 @@
           The <dfn>default orientation</dfn> is the set of orientations to
           which the screen is locked when there is no current <a>orientation
           lock</a>. This orientation is determined by the device's operating
-          system.
+          system or set by the end-user.
         </p>
         <div class="issue" data-number="150"></div>
       </section>


### PR DESCRIPTION
- Added "default orientation" to _5.1 Screen orientation types and locks_
- Clarified role of operating system in "any" and "default" definitions
- Moved locking to the default orientation as a subsection of _5.3 Locking the screen orientation_


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Johanna-hub/screen-orientation/pull/161.html" title="Last updated on Feb 26, 2019, 2:06 PM UTC (5e66056)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-orientation/161/77810af...Johanna-hub:5e66056.html" title="Last updated on Feb 26, 2019, 2:06 PM UTC (5e66056)">Diff</a>