### PR TITLE
respec no longer supports the old ";" delimiter

### DIFF
--- a/W3CTRMANIFEST
+++ b/W3CTRMANIFEST
@@ -1,1 +1,1 @@
-index.html?specStatus=WD;shortName=screen-orientation respec
+index.html?specStatus=WD&shortName=screen-orientation respec


### PR DESCRIPTION
The manifest used by Echidna is no longer valid with the latest versions of respec. This PR updates the delimiter to make it work again.