### PR TITLE
Edit to 5.3.1. Locking to the default orientation 

### DIFF
--- a/index.html
+++ b/index.html
@@ -722,8 +722,12 @@
             From the perspective of a <a>document</a>, locking to the
             <a>default orientation</a> is equivalent to unlocking because it
             means that it no longer has a lock applied. However, this does not
-            mean that the <a>[[\defaultOrientation]]</a> only contains the item
-            <a>any</a>.
+            mean that the <a>[[\defaultOrientation]]</a> should only contain
+            the item <a>any</a>. The <a>default orientation</a> is
+            system-specific and <a>[[\defaultOrientation]]</a> could for
+            example contain <a>portrait-primary</a> and/or
+            <a>landscape-primary</a> or the user could set to a specific
+            preference.
           </p>
         </section>
       </section>

--- a/index.html
+++ b/index.html
@@ -722,12 +722,13 @@
             From the perspective of a <a>document</a>, locking to the
             <a>default orientation</a> is equivalent to unlocking because it
             means that it no longer has a lock applied. However, this does not
-            mean that the <a>[[\defaultOrientation]]</a> should only contain
-            the item <a>any</a>. The <a>default orientation</a> is
-            system-specific and <a>[[\defaultOrientation]]</a> could for
+            mean that the <a>[[\defaultOrientation]]</a> will only contain the
+            item <a>any</a>. The <a>default orientation</a> is likely
+            device-specific and <a>[[\defaultOrientation]]</a> could for
             example contain <a>portrait-primary</a> and/or
-            <a>landscape-primary</a> or the user could set to a specific
-            preference.
+            <a>landscape-primary</a>. Alternatively, the user could restrict
+            the default orientation to a specific orientation via some OS or
+            browser level preference for accessibility reasons.
           </p>
         </section>
       </section>

--- a/index.html
+++ b/index.html
@@ -721,14 +721,18 @@
           <p>
             From the perspective of a <a>document</a>, locking to the
             <a>default orientation</a> is equivalent to unlocking because it
-            means that it no longer has a lock applied. However, this does not
-            mean that the <a>[[\defaultOrientation]]</a> will only contain the
-            item <a>any</a>. The <a>default orientation</a> is likely
-            device-specific and <a>[[\defaultOrientation]]</a> could for
+            means that it no longer has a lock applied.
+          </p>
+          <p class="note" title="Who controls the default orientation?">
+            This does not mean that the <a>[[\defaultOrientation]]</a> will
+            only contain the item <a>any</a>. The <a>default orientation</a> is
+            likely device-specific and <a>[[\defaultOrientation]]</a> could for
             example contain <a>portrait-primary</a> and/or
             <a>landscape-primary</a>. Alternatively, the user could restrict
             the default orientation to a specific orientation via some OS or
-            browser level preference for accessibility reasons.
+            browser level preference for accessibility reasons. The user agent
+            can also set the default orientation e.g., <a href=
+            "#interaction-with-web-application-manifest"></a>.
           </p>
         </section>
       </section>


### PR DESCRIPTION
Added a bit more clarification based on #150


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Johanna-hub/screen-orientation/pull/171.html" title="Last updated on Mar 12, 2019, 5:59 PM UTC (bac9c0d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-orientation/171/5cb4cfd...Johanna-hub:bac9c0d.html" title="Last updated on Mar 12, 2019, 5:59 PM UTC (bac9c0d)">Diff</a>