### PR TITLE
BREAKING CHANGE: unlock() returns a pormise

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,12 +142,17 @@
               show();
               updateDetails(document.getElementById("button"));
             });
+
+            async function doUnlock() {
+              await screen.orientation.unlock();
+              await document.exitFullscreen();
+            }
             &lt;/script&gt;
 
             &lt;button onclick="rotate(this)" id="button"&gt;
               Lock
             &lt;/button&gt;
-            &lt;button onclick="screen.orientation.unlock()"&gt;
+            &lt;button onclick="doUnlock()"&gt;
               Unlock
             &lt;/button&gt;
           </pre>
@@ -256,7 +261,7 @@
           [Exposed=Window]
           interface ScreenOrientation : EventTarget {
             Promise&lt;void&gt; lock(OrientationLockType orientation);
-            void unlock();
+            Promise&lt;void&gt; unlock();
             readonly attribute OrientationType type;
             readonly attribute unsigned short angle;
             attribute EventHandler onchange;
@@ -324,17 +329,9 @@
         </h2>
         <p>
           When the {{unlock()}} method is invoked, the <a>user agent</a> MUST
-          run the steps to <a>lock the orientation</a> of the <a>responsible
-          document</a> to its <a>default orientation</a>.
+          run the steps to <a>apply an orientation lock</a> of the
+          <a>responsible document</a> to its <a>default orientation</a>.
         </p>
-        <p class='note' title="Why does unlock() not return a promise?">
-          {{unlock()}} does not return a promise because it is equivalent to
-          locking to the <a>default orientation</a> which might or might not be
-          known by the <a>user agent</a>. Hence, the <a>user agent</a> can not
-          predict what the new orientation is going to be and even if it is
-          going to change at all.
-        </p>
-        <div class="issue" data-number="104"></div>
       </section>
       <section>
         <h2>
@@ -827,7 +824,8 @@
         </h2>
         <p>
           The steps to <dfn>apply an orientation lock</dfn> to a
-          <a>document</a> using |orientation| are as follows:
+          <a>document</a> using |orientation:OrientationLockType| are as
+          follows:
         </p>
         <ol>
           <li>If the <a>user agent</a> does not support locking the screen


### PR DESCRIPTION
Closes #104 

The following tasks have been completed:

 * [x] Confirmed there are no ReSpec/BikeShed errors or warnings.
 * [x] Modified Web platform tests - Gecko implementation will update the tests

Implementation commitment:

 * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
 * [x] [Gecko](https://bugzilla.mozilla.org/show_bug.cgi?id=1567805)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/screen-orientation/pull/183.html" title="Last updated on Jul 23, 2019, 5:52 AM UTC (9282aad)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-orientation/183/da743fe...9282aad.html" title="Last updated on Jul 23, 2019, 5:52 AM UTC (9282aad)">Diff</a>