### PR TITLE
editorial: remove unused fullscreen element dependency

### DIFF
--- a/index.html
+++ b/index.html
@@ -1156,10 +1156,6 @@
         the descendant browsing contexts</dfn>.
       </p>
       <p>
-        The following is defined in [[FULLSCREEN]]: <dfn data-cite=
-        "FULLSCREEN#fullscreen-element">fullscreen element</dfn>.
-      </p>
-      <p>
         The following is defined in [[PAGE-VISIBILITY]]: <dfn data-cite=
         "PAGE-VISIBILITY#dfn-now-visible-algorithm">now visible
         algorithm</dfn>.


### PR DESCRIPTION
Goal is to remove the spec's [dependencies list](https://w3c.github.io/screen-orientation/#dependencies).

#### Dependencies
1. Fullscreen element - unused, removed in this PR
2. HTML list of the descendant browsing contexts - [PR to export the term. Has ongoing discussion](https://github.com/whatwg/html/pull/5194)
3. Page Visibility now visible algorithm - [issue to export page visibility definitions](https://github.com/w3c/page-visibility)
4. Animation frame task - the linked [issue](https://github.com/whatwg/fullscreen/issues/16) is still pending. There doesn't seem to be a way to link the definition through xref yet.

cc @marcoscaceres 

---

The following tasks have been completed:

 * [x] Confirmed there are no ReSpec/BikeShed errors or warnings.
 * [ ] Modified Web platform tests (link to pull request)

Implementation commitment:

 * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/janiceshiu/screen-orientation/pull/191.html" title="Last updated on Jan 7, 2020, 7:29 AM UTC (a169745)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-orientation/191/7a99fe9...janiceshiu:a169745.html" title="Last updated on Jan 7, 2020, 7:29 AM UTC (a169745)">Diff</a>