### PR TITLE
Adjust dfn markup of "change" event

### DIFF
--- a/index.html
+++ b/index.html
@@ -801,7 +801,7 @@
               to:
                 <ol>
                   <li>
-                    <a>Fire an event</a> named {{ScreenOrientation/change}} at
+                    <a>Fire an event</a> named "[=ScreenOrientation/change=]" at
                     |doc|'s [=relevant global object=]'s
                     [=associated `Screen`=]'s {{Screen/orientation}} attribute.
                   </li>
@@ -851,7 +851,7 @@
               step.
               </li>
               <li>
-                <a>Fire an event</a> named {{ScreenOrientation/change}} at
+                <a>Fire an event</a> named "[=ScreenOrientation/change=]" at
                 |doc|'s [=relevant global object=]'s [=associated `Screen`=]'s
                 {{Screen/orientation}} attribute.
               </li>

--- a/index.html
+++ b/index.html
@@ -524,7 +524,7 @@
       <p>
         The {{onchange}} attribute is an <a>event handler</a> whose
         corresponding <a>event handler event type</a> is
-        <dfn event for="ScreenOrientation">`change`</dfn>.
+        <dfn data-dfn-type="event" data-dfn-for="ScreenOrientation">change</dfn>.
       </p>
     </section>
     <section data-dfn-for="OrientationLockType">
@@ -798,9 +798,9 @@
               to:
                 <ol>
                   <li>
-                    <a>Fire an event</a> named {{change}} at |doc|'s [=relevant
-                    global object=]'s [=associated `Screen`=]'s
-                    {{Screen/orientation}} attribute.
+                    <a>Fire an event</a> named {{ScreenOrientation/change}} at
+                    |doc|'s [=relevant global object=]'s
+                    [=associated `Screen`=]'s {{Screen/orientation}} attribute.
                   </li>
                   <li>If |doc|'s {{Document/[[orientationPendingPromise]]}} is
                   not `null`:
@@ -848,8 +848,8 @@
               step.
               </li>
               <li>
-                <a>Fire an event</a> named {{change}} at |doc|'s [=relevant
-                global object=]'s [=associated `Screen`=]'s
+                <a>Fire an event</a> named {{ScreenOrientation/change}} at
+                |doc|'s [=relevant global object=]'s [=associated `Screen`=]'s
                 {{Screen/orientation}} attribute.
               </li>
               <li>If the {{Document}}'s

--- a/index.html
+++ b/index.html
@@ -526,8 +526,8 @@
       </section>
       <p>
         The {{onchange}} attribute is an <a>event handler</a> whose
-        corresponding <a>event handler event type</a> is
-        <dfn class="event" data-dfn-for="ScreenOrientation">change</dfn>.
+        corresponding <a>event handler event type</a> is <dfn class="event"
+        data-dfn-for="ScreenOrientation">change</dfn>.
       </p>
     </section>
     <section data-dfn-for="OrientationLockType">
@@ -801,9 +801,10 @@
               to:
                 <ol>
                   <li>
-                    <a>Fire an event</a> named "[=ScreenOrientation/change=]" at
-                    |doc|'s [=relevant global object=]'s
-                    [=associated `Screen`=]'s {{Screen/orientation}} attribute.
+                    <a>Fire an event</a> named "<a data-link-for=
+                    "ScreenOrientation">change</a>" at |doc|'s [=relevant
+                    global object=]'s [=associated `Screen`=]'s
+                    {{Screen/orientation}} attribute.
                   </li>
                   <li>If |doc|'s {{Document/[[orientationPendingPromise]]}} is
                   not `null`:
@@ -851,9 +852,10 @@
               step.
               </li>
               <li>
-                <a>Fire an event</a> named "[=ScreenOrientation/change=]" at
-                |doc|'s [=relevant global object=]'s [=associated `Screen`=]'s
-                {{Screen/orientation}} attribute.
+                <a>Fire an event</a> named "<a data-link-for=
+                "ScreenOrientation">change</a>" at |doc|'s [=relevant global
+                object=]'s [=associated `Screen`=]'s {{Screen/orientation}}
+                attribute.
               </li>
               <li>If the {{Document}}'s
               {{Document/[[orientationPendingPromise]]}} is not `null`:

--- a/index.html
+++ b/index.html
@@ -523,7 +523,8 @@
       </section>
       <p>
         The {{onchange}} attribute is an <a>event handler</a> whose
-        corresponding <a>event handler event type</a> is `"change"`.
+        corresponding <a>event handler event type</a> is
+        <dfn event for="ScreenOrientation">`change`</dfn>.
       </p>
     </section>
     <section data-dfn-for="OrientationLockType">
@@ -797,7 +798,7 @@
               to:
                 <ol>
                   <li>
-                    <a>Fire an event</a> named `change` at |doc|'s [=relevant
+                    <a>Fire an event</a> named {{change}} at |doc|'s [=relevant
                     global object=]'s [=associated `Screen`=]'s
                     {{Screen/orientation}} attribute.
                   </li>
@@ -847,7 +848,7 @@
               step.
               </li>
               <li>
-                <a>Fire an event</a> named `"change"` at |doc|'s [=relevant
+                <a>Fire an event</a> named {{change}} at |doc|'s [=relevant
                 global object=]'s [=associated `Screen`=]'s
                 {{Screen/orientation}} attribute.
               </li>

--- a/index.html
+++ b/index.html
@@ -527,7 +527,7 @@
       <p>
         The {{onchange}} attribute is an <a>event handler</a> whose
         corresponding <a>event handler event type</a> is
-        <dfn data-dfn-type="event" data-dfn-for="ScreenOrientation">change</dfn>.
+        <dfn class="event" data-dfn-for="ScreenOrientation">change</dfn>.
       </p>
     </section>
     <section data-dfn-for="OrientationLockType">


### PR DESCRIPTION
This update creates a proper definition and references for the `change` event so that the event can appear with the right parameters in Webref.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/screen-orientation/pull/213.html" title="Last updated on Oct 12, 2022, 6:01 AM UTC (1a683dc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-orientation/213/eddc73d...tidoust:1a683dc.html" title="Last updated on Oct 12, 2022, 6:01 AM UTC (1a683dc)">Diff</a>