### PR TITLE
Editorial: fix walk down all documents from top

### DIFF
--- a/index.html
+++ b/index.html
@@ -425,12 +425,17 @@
           <li>Return |document|'s {{Document/[[orientationPendingPromise]]}}
           and [=in parallel=]:
             <ol>
+              <li>Let |topDocument| be [=top-level browsing context=]'s
+              [=active document=].
+              </li>
               <li>Let |descendantDocs| be an [=ordered set=] consisting of
-              |documents|'s [=descendant browsing contexts=]' [=active
+              |topDocument|'s [=descendant browsing contexts=]' [=active
               documents=], if any, in tree order.
               </li>
               <li>[=Set/For each=] |doc:Document| in |descendantDocs|:
                 <ol>
+                  <li>If |doc| is |document|, continue.
+                  </li>
                   <li>If |doc| {{Document/[[orientationPendingPromise]]}} is
                   `null`, continue.
                   </li>


### PR DESCRIPTION
Closes #192
Closes #193
Closes #198

The following tasks have been completed:

 * [ ] Modified Web platform tests (link to pull request)

Implementation commitment:

 * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/screen-orientation/pull/216.html" title="Last updated on Oct 14, 2022, 7:57 AM UTC (320f0c2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-orientation/216/1ab4b3d...320f0c2.html" title="Last updated on Oct 14, 2022, 7:57 AM UTC (320f0c2)">Diff</a>