### PR TITLE
Clarify that locking to every orientation might not be supported

### DIFF
--- a/index.html
+++ b/index.html
@@ -386,8 +386,9 @@
           <dfn>lock()</dfn> method
         </h2>
         <p data-tests="lock-bad-argument.html, lock-basic.html">
-          When the {{lock()}} method is invoked, the <a>user agent</a> MUST run
-          the the following steps.
+          When the {{lock()}} method is invoked with
+          |orientation:OrientationLockType|, the <a>user agent</a> MUST run the
+          the following steps.
         </p>
         <ol class="algorithm">
           <li>Let |document:Document| be [=this=]'s [=relevant global
@@ -399,6 +400,10 @@
           <li>If the <a>user agent</a> does not support locking the screen
           orientation due to previously-established user preference, security
           risk, or platform limitation, return [=a promise rejected with=] a
+          {{"NotSupportedError"}} {{DOMException}} and abort these steps.
+          </li>
+          <li>If the <a>user agent</a> does not support locking the screen
+          orientation to |orientation|, return [=a promise rejected with=] a
           {{"NotSupportedError"}} {{DOMException}} and abort these steps.
           </li>
           <li data-tests="lock-sandboxed-iframe.html">If |document| has the <a>
@@ -548,10 +553,16 @@
       </pre>
       <p>
         The <dfn>OrientationLockType</dfn> enum represents the screen
-        orientations to which a screen can be potentially locked to. [=User
-        agents=] are NOT REQUIRED to support locking the screen orientation to
-        any of the values in the {{OrientationLockType}} enum.
+        orientations to which a screen can be potentially locked to.
       </p>
+      <aside class="note" title="Orientation support">
+        <p>
+          User agents might only support a subset of the possible
+          {{OrientationLockType}} values. For example, a user agent might not
+          support locking to the `"portrait-secondary"` or
+          `"landscape-secondary"` orientations.
+        </p>
+      </aside>
       <ul>
         <li>"<dfn>any</dfn>" enum value represents the <a>any</a> orientation,
         </li>

--- a/index.html
+++ b/index.html
@@ -388,7 +388,7 @@
         <p data-tests="lock-bad-argument.html, lock-basic.html">
           When the {{lock()}} method is invoked with
           |orientation:OrientationLockType|, the <a>user agent</a> MUST run the
-          the following steps.
+          the following steps:
         </p>
         <ol class="algorithm">
           <li>Let |document:Document| be [=this=]'s [=relevant global

--- a/index.html
+++ b/index.html
@@ -548,7 +548,9 @@
       </pre>
       <p>
         The <dfn>OrientationLockType</dfn> enum represents the screen
-        orientations to which a screen can be rotated.
+        orientations to which a screen can be potentially locked to. [=User
+        agents=] are NOT REQUIRED to support locking the screen orientation to
+        any of the values in the {{OrientationLockType}} enum.
       </p>
       <ul>
         <li>"<dfn>any</dfn>" enum value represents the <a>any</a> orientation,


### PR DESCRIPTION
Some implementations might not support locking to particular orientations. 

Closes #???

The following tasks have been completed:

 * [X] [Modified Web platform tests](https://github.com/web-platform-tests/wpt/pull/36392)

Implementation commitment:

 * [x] WebKit
 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/screen-orientation/pull/217.html" title="Last updated on Oct 14, 2022, 12:32 AM UTC (f8b9885)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-orientation/217/73136d8...f8b9885.html" title="Last updated on Oct 14, 2022, 12:32 AM UTC (f8b9885)">Diff</a>