### PR TITLE
Consume user activation

### DIFF
--- a/index.html
+++ b/index.html
@@ -390,8 +390,9 @@
           the the following steps.
         </p>
         <ol class="algorithm">
-          <li>Let |document:Document| be [=this=]'s [=relevant global
-          object=]'s [=associated `Document`=].
+          <li>Let |global:Window| be [=this=]'s [=relevant global object=].
+          </li>
+          <li>Let |document:Document| be |global|'s [=associated `Document`=].
           </li>
           <li>If |document| is not [=Document/fully active=], return [=a
           promise rejected with=] an "{{InvalidStateError}}" {{DOMException}}.
@@ -406,6 +407,11 @@
             doesn't meet the [=pre-lock conditions=], return [=a promise
             rejected with=] a `"SecurityError"` {{DOMException}} and abort
             these steps.
+          </li>
+          <li>If |global| does not have [=transient activation=], return [=a
+          promise rejected with=] a {{"NotAllowedError"}} {{DOMException}}.
+          </li>
+          <li>[=Consume user activation=] of |global|.
           </li>
           <li data-tests="lock-basic.html">If |document|'s
           {{Document/[[orientationPendingPromise]]}} is not `null`:


### PR DESCRIPTION
Closes #210 

The purpose of this change is to somewhat mitigate the following abuse case, which could be used for hypothetical fingerprinting attack. It could also just generally annoy users if web applications can randomly change orientation while in fullscreen.    

```JS
await video.requestFullscreen();
// now quickly before user notices, switch all orientations  
for (const orientation of allOrientationsInTheSpec) {
  // Scan the user's supported orientations
  // to add to fingerprint
  const support = {yep: [], nope: []};
  try {
      await screen.orientation.lock(orientation);
      support.yep.push(orientation)
   } catch {
      support.nope.push(orientation)
   }
}
```

The following tasks have been completed:

 * [ ] Modified Web platform tests (link to pull request)

Implementation commitment:

 * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/screen-orientation/pull/218.html" title="Last updated on Sep 27, 2024, 10:55 PM UTC (93d7ada)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-orientation/218/7534ec9...93d7ada.html" title="Last updated on Sep 27, 2024, 10:55 PM UTC (93d7ada)">Diff</a>