### PR TITLE
Restrict locking to visible documents

### DIFF
--- a/index.html
+++ b/index.html
@@ -477,6 +477,10 @@
           orientation to |orientation|, return [=a promise rejected with=] a
           {{"NotSupportedError"}} {{DOMException}} and abort these steps.
           </li>
+          <li>If |document|'s [=Document/visibility state=] is "hidden", return
+          [=a promise rejected with=] an {{"NotAllowedError"}} {{DOMException}}
+          and abort these steps.
+          </li>
           <li data-tests="lock-basic.html">If |document|'s
           {{Document/[[orientationPendingPromise]]}} is not `null`, [=reject
           and nullify the current lock promise=] of |document| with an


### PR DESCRIPTION
Closes #221 

The following tasks have been completed:

 * [ ] Modified Web platform tests (link to pull request)

Implementation commitment:

 * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/screen-orientation/pull/230.html" title="Last updated on Oct 31, 2022, 1:25 AM UTC (b98361c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-orientation/230/206c506...b98361c.html" title="Last updated on Oct 31, 2022, 1:25 AM UTC (b98361c)">Diff</a>