### PR TITLE
Prevent hidden documents from locking orientation

### DIFF
--- a/index.html
+++ b/index.html
@@ -470,13 +470,13 @@
           risk, return [=a promise rejected with=] a {{"SecurityError"}}
           {{DOMException}} and abort these steps.
           </li>
+          <li>If |document|'s [=Document/visibility state=] is "hidden", return
+          [=a promise rejected with=] an {{"SecurityError"}} {{DOMException}}
+          and abort these steps.
+          </li>
           <li>If the [=user agent=] does not support locking the screen
           orientation to |orientation|, return [=a promise rejected with=] a
           {{"NotSupportedError"}} {{DOMException}} and abort these steps.
-          </li>
-          <li>If |document|'s [=Document/visibility state=] is "hidden", return
-          [=a promise rejected with=] an {{"NotAllowedError"}} {{DOMException}}
-          and abort these steps.
           </li>
           <li data-tests="lock-basic.html">If |document|'s
           {{Document/[[orientationPendingPromise]]}} is not `null`, [=reject
@@ -511,16 +511,16 @@
           [=sandboxed orientation lock browsing context flag=] set, return
           `undefined`.
           </li>
+          <li>If |document|'s [=Document/visibility state=] is "hidden",
+          [=exception/throw=] a {{"SecurityError"}} {{DOMException}} and abort
+          these steps.
+          </li>
           <li>If screen's [=Screen/active orientation lock=] is `null`, return
           `undefined`.
           </li>
           <li>If |document|'s {{Document/[[orientationPendingPromise]]}} is not
           `null`, [=reject and nullify the current lock promise=] of |document|
           with an {{"AbortError"}}.
-          </li>
-          <li>If |document|'s [=Document/visibility state=] is "hidden",
-          [=exception/throw=] a {{"NotAllowedError"}} {{DOMException}} and
-          abort these steps.
           </li>
           <li>[=Apply orientation lock=] `null` to |document|.
           </li>

--- a/index.html
+++ b/index.html
@@ -474,6 +474,10 @@
           orientation to |orientation|, return [=a promise rejected with=] a
           {{"NotSupportedError"}} {{DOMException}} and abort these steps.
           </li>
+          <li>If |document|'s [=Document/visibility state=] is "hidden", return
+          [=a promise rejected with=] an {{"NotAllowedError"}} {{DOMException}}
+          and abort these steps.
+          </li>
           <li data-tests="lock-basic.html">If |document|'s
           {{Document/[[orientationPendingPromise]]}} is not `null`, [=reject
           and nullify the current lock promise=] of |document| with an

--- a/index.html
+++ b/index.html
@@ -518,6 +518,10 @@
           `null`, [=reject and nullify the current lock promise=] of |document|
           with an {{"AbortError"}}.
           </li>
+          <li>If |document|'s [=Document/visibility state=] is "hidden",
+          [=exception/throw=] a {{"NotAllowedError"}} {{DOMException}} and
+          abort these steps.
+          </li>
           <li>[=Apply orientation lock=] `null` to |document|.
           </li>
         </ol>


### PR DESCRIPTION
Closes #221 

The following tasks have been completed:

 * [x] [Modified Web platform tests](https://github.com/web-platform-tests/wpt/pull/36734)

Implementation commitment:

 * [x] [WebKit](https://bugs.webkit.org/show_bug.cgi?id=247248) - [patch](https://github.com/WebKit/WebKit/pull/6283)
 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=1802823)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/screen-orientation/pull/232.html" title="Last updated on Feb 15, 2023, 5:35 AM UTC (638c545)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-orientation/232/9dc8f9d...638c545.html" title="Last updated on Feb 15, 2023, 5:35 AM UTC (638c545)">Diff</a>