### PR TITLE
Editorial: always null check orientationPendingPromise

### DIFF
--- a/index.html
+++ b/index.html
@@ -680,7 +680,7 @@
           |exceptionName|, the [=user agent=] MUST:
         </p>
         <ol class="algorithm" data-tests="orientation-locking.html">
-          <li>Assert: {{Document/[[orientationPendingPromise]]}} is not `null`.
+          <li>[=/Assert=]: {{Document/[[orientationPendingPromise]]}} is not `null`.
           </li>
           <li>Let |promise:Promise| be |document|'s
           {{Document/[[orientationPendingPromise]]}}.

--- a/index.html
+++ b/index.html
@@ -680,8 +680,7 @@
           |exceptionName|, the [=user agent=] MUST:
         </p>
         <ol class="algorithm" data-tests="orientation-locking.html">
-          <li>If |document|'s {{Document/[[orientationPendingPromise]]}} is
-          `null`, abort these steps.
+          <li>Assert: {{Document/[[orientationPendingPromise]]}} is not `null`.
           </li>
           <li>Let |promise:Promise| be |document|'s
           {{Document/[[orientationPendingPromise]]}}.
@@ -705,8 +704,9 @@
       </p>
       <ol>
         <li>If |document| stops being [=Document/fully active=] while [=in
-        parallel=], [=reject and nullify the current lock promise=] of
-        |document| with an {{"AbortError"}}.
+        parallel=], and {{Document/[[orientationPendingPromise]]}} is not
+        `null`, [=reject and nullify the current lock promise=] of |document|
+        with an {{"AbortError"}}.
         </li>
         <li>Let |topDocument| be |document|'s [=top-level browsing context=]'s
         [=active document=].

--- a/index.html
+++ b/index.html
@@ -680,7 +680,8 @@
           |exceptionName|, the [=user agent=] MUST:
         </p>
         <ol class="algorithm" data-tests="orientation-locking.html">
-          <li>[=/Assert=]: {{Document/[[orientationPendingPromise]]}} is not `null`.
+          <li>[=/Assert=]: {{Document/[[orientationPendingPromise]]}} is not
+          `null`.
           </li>
           <li>Let |promise:Promise| be |document|'s
           {{Document/[[orientationPendingPromise]]}}.


### PR DESCRIPTION
Closes #233


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/screen-orientation/pull/235.html" title="Last updated on Oct 31, 2022, 3:12 AM UTC (8b66258)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-orientation/235/206c506...8b66258.html" title="Last updated on Oct 31, 2022, 3:12 AM UTC (8b66258)">Diff</a>