### PR TITLE
Fix error in example usage

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,6 +80,7 @@
           function getOppositeOrientation() {
             return screen
               .orientation
+              .type
               .startsWith("portrait") ? "landscape" : "portrait";
           }
 


### PR DESCRIPTION
Closes #245

@Maferep caught that the example treats `screen.orientation` as a string instead of an object. Updates the example to use `.type` instead.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/screen-orientation/pull/246.html" title="Last updated on Apr 2, 2023, 8:24 PM UTC (1c9e0e6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-orientation/246/c0fcb39...1c9e0e6.html" title="Last updated on Apr 2, 2023, 8:24 PM UTC (1c9e0e6)">Diff</a>