### PR TITLE
Standardize angle orientations counter-clockwise

### DIFF
--- a/index.html
+++ b/index.html
@@ -220,9 +220,9 @@
             <dfn data-dfn-for="Screen">Current orientation angle</dfn>
           </dt>
           <dd>
-            The angle in degrees that the screen is rotated clockwise from its
-            [=natural=] orientation as derived by the [=screen orientation
-            values table=].
+            The angle in degrees that the screen is rotated counter-clockwise
+            from its [=natural=] orientation as derived by the [=screen
+            orientation values list=].
           </dd>
           <dt>
             <dfn data-dfn-for="Screen">Active orientation lock</dfn>
@@ -234,95 +234,42 @@
           </dd>
         </dl>
         <p>
-          The <a>screen orientation values table</a> presents the possible
-          value for the [=Screen/current orientation type=] and
-          [=Screen/current orientation angle=]. The table specifies the
-          [=primary=] and [=secondary=] values that are determined by the
-          device's [=natural=] orientation and the possibilities available to
-          the [=user agent=] for setting the other primary and secondary
-          orientation values.
+          The <dfn>screen orientation values lists</dfn> below standardize the
+          angles associated with each screen orientation type for screens with
+          different [=natural=] orientations:
         </p>
-        <table class="simple">
-          <caption>
-            The <dfn>screen orientation values table</dfn>
-          </caption>
-          <thead>
-            <tr>
-              <th>
-                In the natural orientation is...
-              </th>
-              <th>
-                Primary Orientation
-              </th>
-              <th>
-                Secondary Orientation
-              </th>
-              <th>
-                Primary Orientation (alternative)
-              </th>
-              <th>
-                Secondary Orientation (alternative)
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>
-                <a>Portrait</a>
-              </td>
-              <td>
-                [=portrait-primary=]<br>
-                angle `0`
-              </td>
-              <td>
-                <a>portrait-secondary</a><br>
-                angle `180`
-              </td>
-              <td>
-                <a>landscape-primary</a><br>
-                angle `90` or angle `270`
-              </td>
-              <td>
-                <a>landscape-secondary</a><br>
-                The angle not used for [=landscape-primary=].
-              </td>
-            </tr>
-            <tr>
-              <td>
-                [=Landscape=]
-              </td>
-              <td>
-                [=landscape-primary=]<br>
-                angle `0`
-              </td>
-              <td>
-                <a>landscape-secondary</a><br>
-                angle `180`
-              </td>
-              <td>
-                [=portrait-primary=]<br>
-                angle `90` or angle `270`
-              </td>
-              <td>
-                <a>portrait-secondary</a><br>
-                The angle not used for [=portrait-primary=].
-              </td>
-            </tr>
-          </tbody>
-        </table>
-        <div class="practice">
-          <p class="practicedesc">
-            <span class="practicelab">{{ScreenOrientation/angle}} and
-            {{ScreenOrientation/type}} relationship</span> Never assume any
-            cross-devices relationship between the screen orientation type and
-            the screen orientation angle. Any assumption would be wrong given
-            that a device might have `90` and `270` as the angles for
-            `landscape` types but another device will have `0` and `180`,
-            depending on its [=natural=] orientation. Instead, it is
-            recommended to check during runtime the relationship between angle
-            and type.
-          </p>
-        </div>
+        <dl>
+          <dt>
+            For screens with a [=natural=] [=portrait=] orientation:
+          </dt>
+          <dd>
+            <ul>
+              <li>[=portrait-primary=]: 0°
+              </li>
+              <li>[=landscape-primary=]: 90°
+              </li>
+              <li>[=portrait-secondary=]: 180°
+              </li>
+              <li>[=landscape-secondary=]: 270°
+              </li>
+            </ul>
+          </dd>
+          <dt>
+            For screens with a [=natural=] [=landscape=] orientation:
+          </dt>
+          <dd>
+            <ul>
+              <li>[=landscape-primary=]: 0°
+              </li>
+              <li>[=portrait-primary=]: 90°
+              </li>
+              <li>[=landscape-secondary=]: 180°
+              </li>
+              <li>[=portrait-secondary=]: 270°
+              </li>
+            </ul>
+          </dd>
+        </dl>
       </section>
     </section>
     <section>
@@ -416,7 +363,8 @@
               </td>
               <td>
                 Represents the screen's last known [=Screen/current orientation
-                angle=] in degrees as an {{unsigned short}}.
+                angle=] in degrees as an {{unsigned short}} as derived from the
+                [=screen orientation values lists=].
               </td>
             </tr>
             <tr>
@@ -554,7 +502,7 @@
           <p>
             The {{ScreenOrientation/angle}} attribute represents how far the
             screen has rotated from it [=natural=] orientation. The <a>screen
-            orientation values table</a> specifies how the angle changes
+            orientation values list</a> specifies how the angle changes
             depending on the how screen is rotated.
           </p>
         </aside>


### PR DESCRIPTION
Closes #247 

The following tasks have been completed:

 * [x] [Modified Web platform tests](https://github.com/web-platform-tests/wpt/pull/39515)

Implementation commitment:

 * [x] [WebKit](https://bugs.webkit.org/show_bug.cgi?id=255388)
 * [X] Chromium  - current behavior 
 * [X] Gecko - current behavior


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/screen-orientation/pull/248.html" title="Last updated on Apr 14, 2023, 1:39 AM UTC (0618c41)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-orientation/248/c6a0731...0618c41.html" title="Last updated on Apr 14, 2023, 1:39 AM UTC (0618c41)">Diff</a>