### PR TITLE
Fix iframe promise rejection in unloading document cleanup

### DIFF
--- a/index.html
+++ b/index.html
@@ -847,12 +847,16 @@
         |document|, the user agent MUST run the following steps:
       </p>
       <ol class="algorithm">
-        <li>If |document|'s {{Document/[[orientationPendingPromise]]}} is not
-        `null`, [=reject and nullify the current lock promise=] of |document|
-        with an {{"AbortError"}}.
-        </li>
         <li>If |document| is not a [=top-level traversable=]'s
-        [=navigable/active document=], abort these steps.
+        [=navigable/active document=]:
+          <ol>
+            <li>If |document|'s {{Document/[[orientationPendingPromise]]}} is
+            not `null`, [=reject and nullify the current lock promise=] of
+            |document| with an {{"AbortError"}}.
+            </li>
+            <li>Abort these steps.
+            </li>
+          </ol>
         </li>
         <li>Run the [=fully unlock the screen orientation steps=] with
         |document|.

--- a/index.html
+++ b/index.html
@@ -834,6 +834,10 @@
         |document|, the user agent MUST run the following steps:
       </p>
       <ol class="algorithm">
+        <li>If |document|'s {{Document/[[orientationPendingPromise]]}} is not
+        `null`, [=reject and nullify the current lock promise=] of |document|
+        with an {{"AbortError"}}.
+        </li>
         <li>If |document| is not a [=top-level browsing context=]'s
         [=navigable/active document=], abort these steps.
         </li>


### PR DESCRIPTION
Resolves specification inconsistency where iframe documents with pending orientation lock promises were not having their promises rejected during document unloading.

The previous algorithm would abort cleanup steps for non-top-level documents before rejecting pending promises. This fix separates two concerns:
1. Promise rejection (happens for ALL documents including iframes)
2. Screen orientation unlocking (only happens for top-level documents)

This aligns the specification with the Web Platform Test expectations in active-lock.html which expects iframe lock promises to be rejected with AbortError when the iframe document is unloaded.

Closes #257 

The following tasks have been completed:

 * [ ] Modified Web platform tests (link to pull request)

Implementation commitment:

 * [ ] WebKit (https://bugs.webkit.org/enter_bug.cgi)
 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/screen-orientation/pull/268.html" title="Last updated on Jul 23, 2026, 9:58 AM UTC (cd1f403)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-orientation/268/a8d0379...cd1f403.html" title="Last updated on Jul 23, 2026, 9:58 AM UTC (cd1f403)">Diff</a>