### PR TITLE
Add continuous monitoring for pre-lock conditions

### DIFF
--- a/index.html
+++ b/index.html
@@ -882,9 +882,14 @@
       </h2>
       <p>
         A user agent MUST restrict the use of {{ScreenOrientation/lock()}} to
-        simple fullscreen documents as a [=pre-lock condition=]. This
+        [=simple fullscreen documents=] as a [=pre-lock condition=]. This
         requirement prevents fingerprinting through differences in user agent
         behavior regarding orientation locking permissions. [[fullscreen]]
+      </p>
+      <p>
+        If a [=document=] [=Document/has pending fullscreen request=], the user
+        agent MUST await the [=Document/pending fullscreen request promise=]
+        before evaluating the [=pre-lock conditions=]. [[fullscreen]]
       </p>
       <p>
         When a [=document=] exits fullscreen, it also runs the [=fully unlock

--- a/index.html
+++ b/index.html
@@ -668,6 +668,10 @@
         `null`, [=reject and nullify the current lock promise=] of |document|
         with an {{"AbortError"}}.
         </li>
+        <li>If any [=pre-lock conditions=] are no longer met while [=in
+        parallel=], run the [=fully unlock the screen orientation steps=]
+        with |document|.
+        </li>
         <li>Let |topDocument| be |document|'s [=top-level browsing context=]'s
         [=navigable/active document=].
         </li>

--- a/index.html
+++ b/index.html
@@ -669,9 +669,7 @@
         `null`, [=reject and nullify the current lock promise=] of |document|
         with an {{"AbortError"}}.
         </li>
-        <li>If any [=pre-lock conditions=] are no longer met while [=in
-        parallel=], run the [=fully unlock the screen orientation steps=]
-        with |document|.
+        <li>[=In parallel=], if any [=pre-lock conditions=] are no longer met, run the [=fully unlock the screen orientation steps=] with |document|.
         </li>
         <li>Let |topDocument| be |document|'s [=top-level browsing context=]'s
         [=navigable/active document=].

--- a/index.html
+++ b/index.html
@@ -669,7 +669,8 @@
         `null`, [=reject and nullify the current lock promise=] of |document|
         with an {{"AbortError"}}.
         </li>
-        <li>[=In parallel=], if any [=pre-lock conditions=] are no longer met, run the [=fully unlock the screen orientation steps=] with |document|.
+        <li>[=In parallel=], if any [=pre-lock conditions=] are no longer met,
+        run the [=fully unlock the screen orientation steps=] with |document|.
         </li>
         <li>Let |topDocument| be |document|'s [=top-level browsing context=]'s
         [=navigable/active document=].
@@ -945,14 +946,14 @@
       </ul>
       <p>
         The requirement for [=documents=] to be [=Document/fully active
-        descendant of a top-level traversable with user attention=] ensures that
-        orientation events are only delivered to
-        documents in windows that are both visible at the system level and have
-        the user's attention (either through focus or the ability to receive
-        keyboard input). The additional visibility state check provides defense
-        in depth. These restrictions prevent background tabs, hidden windows,
-        and minimized applications from collecting orientation data for
-        fingerprinting purposes.
+        descendant of a top-level traversable with user attention=] ensures
+        that orientation events are only delivered to documents in windows that
+        are both visible at the system level and have the user's attention
+        (either through focus or the ability to receive keyboard input). The
+        additional visibility state check provides defense in depth. These
+        restrictions prevent background tabs, hidden windows, and minimized
+        applications from collecting orientation data for fingerprinting
+        purposes.
       </p>
       <h3>
         Anti-fingerprinting Mitigations


### PR DESCRIPTION
- Added monitoring step in 'apply orientation lock' algorithm
- Ensures pre-lock conditions (fullscreen, installed app status) are continuously checked
- Automatically runs 'fully unlock' steps when conditions no longer hold
- Provides general catch-all beyond existing Fullscreen API integration
- Improves user experience and security by preventing stale orientation locks

Closes #243

The following tasks have been completed:

 * [ ] Modified Web platform tests (link to pull request)

Implementation commitment:

 * [ ] WebKit (https://bugs.webkit.org/enter_bug.cgi)
 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/screen-orientation/pull/270.html" title="Last updated on Feb 16, 2026, 2:15 AM UTC (8c19744)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-orientation/270/a8d0379...8c19744.html" title="Last updated on Feb 16, 2026, 2:15 AM UTC (8c19744)">Diff</a>