### PR TITLE
Standardize window.orientation API

### DIFF
--- a/index.html
+++ b/index.html
@@ -312,6 +312,55 @@
         </table>
       </section>
     </section>
+    <section data-dfn-for="Window">
+      <h2>
+        Extensions to the `Window` interface
+      </h2>
+      <pre class="idl">
+        partial interface Window {
+          readonly attribute short orientation;
+          attribute EventHandler onorientationchange;
+        };
+      </pre>
+      <section>
+        <h2>
+          `orientation` attribute
+        </h2>
+        <p>
+          When getting the {{Window/orientation}} attribute, the [=user agent=] MUST run
+          the following steps:
+        </p>
+        <ol class="algorithm">
+          <li>Let |orientationAngle| be the [=Screen/current orientation angle=].
+          </li>
+          <li>If |orientationAngle| is less than 180, return |orientationAngle|.
+          </li>
+          <li>If |orientationAngle| is 180, and the [=user agent=] supports that value,
+          return |orientationAngle|, else return 0.
+          </li>
+          <li>If |orientationAngle| is greater than 180, return |orientationAngle| - 360.
+          </li>
+        </ol>
+        <p>
+          User agents MUST support the `-90`, `0` and `90` values and MAY optionally support `180`.
+        </p>
+        <p class="note">
+          `0` represents the natural orientation, `-90` represents 90 degrees clockwise,
+          `90` represents 90 degrees counterclockwise, and `180` represents 180 degrees
+          from natural orientation.
+        </p>
+      </section>
+      <section>
+        <h2>
+          `onorientationchange` event handler attribute
+        </h2>
+        <p>
+          The {{Window/onorientationchange}} attribute is an [=event handler IDL attribute=] for
+          the {{Window/onorientationchange}} [=event handler=], whose [=event handler event type=]
+          is <dfn class="event" data-dfn-for="Window">orientationchange</dfn>.
+        </p>
+      </section>
+    </section>
     <section data-dfn-for="Screen">
       <h2>
         Extensions to the `Screen` interface
@@ -800,6 +849,9 @@
             </li>
             <li>[=Fire an event=] named "<a data-link-for=
             "ScreenOrientation">change</a>" at |screenOrientation|.
+            </li>
+            <li>[=Fire an event=] named "<a data-link-for=
+            "Window">orientationchange</a>" at |document|'s [=relevant global object=].
             </li>
           </ol>
         </li>


### PR DESCRIPTION
- Add Window interface extension with orientation attribute and onorientationchange handler
- Integrate orientationchange event firing into existing screen orientation change steps
- Map window.orientation values according to WHATWG compat spec algorithm
- Support required values (-90, 0, 90) and optional 180° value
- Remove device-specific restrictions to support device-independent web

This moves window.orientation from WHATWG compat spec to Screen Orientation spec where it belongs conceptually, providing a single authoritative definition.

Fixes #249

The following tasks have been completed:

 * [ ] [Modified Web platform tests](https://github.com/web-platform-tests/wpt/pull/55503)

Implementation commitment:

 * [X] WebKit - already implemented. 
 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/screen-orientation/pull/271.html" title="Last updated on Nov 11, 2025, 8:01 AM UTC (be2ec20)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-orientation/271/a8d0379...be2ec20.html" title="Last updated on Nov 11, 2025, 8:01 AM UTC (be2ec20)">Diff</a>