### PR TITLE
Add hidden document monitoring in parallel orientation lock steps

### DIFF
--- a/index.html
+++ b/index.html
@@ -694,6 +694,11 @@
             not `null`, [=reject and nullify the current lock promise=] of
             |document| with an {{"AbortError"}} and abort these steps.
             </li>
+            <li>If |document|'s [=Document/visibility state=] becomes "hidden", and
+            if the |document|'s {{Document/[[orientationPendingPromise]]}} is
+            not `null`, [=reject and nullify the current lock promise=] of
+            |document| with an {{"AbortError"}} and abort these steps.
+            </li>
             <li>If |orientation| is `null`, [=unlock the screen orientation=].
             </li>
             <li>Otherwise, attempt to [=lock the screen orientation=] to


### PR DESCRIPTION
The 'apply orientation lock' algorithm monitors if documents stop being fully active during parallel execution, but was missing equivalent monitoring for document visibility state changes.

This creates inconsistency where:
- Common safety checks prevent hidden documents from starting locks
- Parallel steps monitor fully-active state changes
- But parallel steps don't monitor hidden state changes

This fix adds monitoring for documents becoming hidden during parallel orientation lock processing, with consistent AbortError rejection.

Fixes #256

The following tasks have been completed:

 * [ ] Modified Web platform tests (link to pull request)

Implementation commitment:

 * [ ] WebKit (https://bugs.webkit.org/enter_bug.cgi)
 * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
 * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/screen-orientation/pull/272.html" title="Last updated on Oct 28, 2025, 7:09 AM UTC (0cf62fe)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-orientation/272/a8d0379...0cf62fe.html" title="Last updated on Oct 28, 2025, 7:09 AM UTC (0cf62fe)">Diff</a>