### PR TITLE
Editorial: clarify the natural screen orientation

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,12 +142,23 @@
             <dfn>Natural</dfn>
           </dt>
           <dd>
-            The most natural orientation for the device's display as determined
-            by the user agent, the user, the operating system, or the screen
-            itself. For example, a device viewed, or held upright in the user's
-            hand, with the screen facing the user. A computer monitor are
-            commonly naturally [=landscape-primary=], while a mobile phones are
-            commonly naturally [=portrait-primary=].
+            The reference orientation for the device's display, from which
+            orientation angles are measured, as determined by the user agent,
+            the user, the operating system, or the screen itself. For example,
+            a computer monitor's reference orientation is typically
+            [=landscape-primary=], while the reference orientation for a mobile
+            phone is typically [=portrait-primary=].
+            <p class="note">
+              How a user agent determines the [=natural=] orientation is
+              implementation-defined and varies by platform. Some user agents
+              use a fixed orientation per device class (for example,
+              [=portrait-primary=] for handsets and [=landscape-primary=] for
+              tablets, desktops, and TVs), while others derive it from the
+              screen's physical dimensions and current rotation. For devices
+              without an obvious upright, such as square or foldable screens,
+              the [=natural=] orientation can therefore differ between user
+              agents.
+            </p>
           </dd>
           <dt>
             <dfn>Landscape</dfn>


### PR DESCRIPTION
Reframes the definition of the natural screen orientation as the reference orientation from which angles are measured, fixes two grammar errors in the old prose, and adds a note that how the natural orientation is determined is implementation-defined, which is why it can differ for square or foldable screens.

Closes #275

 * [x] ~~Modified Web platform tests~~ — editorial clarification, no observable behavior change

Implementation commitment:

 * [ ] WebKit
 * [ ] Chromium
 * [ ] Gecko


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/screen-orientation/pull/278.html" title="Last updated on Jul 23, 2026, 6:35 AM UTC (81d4b86)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/screen-orientation/278/a8d0379...81d4b86.html" title="Last updated on Jul 23, 2026, 6:35 AM UTC (81d4b86)">Diff</a>